### PR TITLE
Define the release URLs as properties

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -24,6 +24,8 @@
       # ${project.artifactId}, ${project.version}, ${RELEASE}, ${maven.build.timestamp}
       #
     </build-info>
+    <release.url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-releases</release.url>
+    <snapshot.url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-snapshots/</snapshot.url>
   </properties>
 
   <dependencies>
@@ -46,7 +48,7 @@
   <repositories>
     <repository>
       <id>quattor-releases</id>
-      <url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-releases</url>
+      <url>${release.url}</url>
     </repository>
   </repositories>
 
@@ -347,12 +349,12 @@
 	<repository>
 	  <id>quattor.releases</id>
 	  <name>Releases</name>
-	  <url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-releases/</url>
+	  <url>${release.url}</url>
 	</repository>
 	<snapshotRepository>
 	  <id>quattor.snapshots</id>
 	  <name>Snapshots</name>
-	  <url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-snapshots/</url>
+	  <url>${snapshot.url}</url>
 	</snapshotRepository>
       </distributionManagement>
     </profile>


### PR DESCRIPTION
Allows some sites to build and release internal components without trying to
reach Stratuslab's repositories.
