### PR TITLE
Update the documentation for the archetype test.

### DIFF
--- a/cfg-module/src/main/resources/archetype-resources/src/test/perl/00-load.t
+++ b/cfg-module/src/main/resources/archetype-resources/src/test/perl/00-load.t
@@ -9,8 +9,8 @@
 
 Basic test that ensures that our module will load correctly.
 
-B<Do not disable this test>. And do not push anything upstream having
-run, at least, this test.
+B<Do not disable this test>. And do not push anything upstream without
+having run, at least, this test.
 
 =cut
 


### PR DESCRIPTION
We don't push to SourceForge anymore.  This follows the recommendation from
@ned21 in configuration-modules-core#22.
