### PR TITLE
Use a property for installing all man pages

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -26,6 +26,7 @@
     </build-info>
     <release.url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-releases</release.url>
     <snapshot.url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-snapshots/</snapshot.url>
+    <man.page.dir>/usr/share/man</man.page.dir>
   </properties>
 
   <dependencies>
@@ -443,7 +444,7 @@
               </mapping>
 
               <mapping>
-                <directory>/usr/share/man</directory>
+                <directory>${man.page.dir}</directory>
                 <filemode>644</filemode>
                 <username>root</username>
                 <groupname>root</groupname>


### PR DESCRIPTION
Fixes #3.

CAF, CCM and LC have their man pages installed in a non-standerd location, and this inconsistency leads to man not reaching some of its pages.

Thanks to @ned21 for the report.
