### PR TITLE
allow command logging in mocked CAF::Process

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -62,6 +62,12 @@ use Cwd;
 use Carp qw(carp croak);
 use File::Path qw(mkpath);
 use Test::MockModule;
+use Test::More;
+
+# boolean to enable logging of each command that is run via CAF::Process
+our $log_cmd = 0;
+# boolean to log each cmd that has output mocked but has no output set
+our $log_cmd_missing = 0;
 
 =pod
 
@@ -220,6 +226,7 @@ foreach my $method (qw(run execute trun)) {
     $procs->mock($method, sub {
 		    my $self = shift;
 		    my $cmd = join(" ", @{$self->{COMMAND}});
+            diag("$method command $cmd") if $log_cmd;
 		    $commands_run{$cmd} = { object => $self,
 					    method => $method
 					  };
@@ -247,10 +254,16 @@ foreach my $method (qw(output toutput)) {
 		    my $self = shift;
 
 		    my $cmd = join(" ", @{$self->{COMMAND}});
+            diag("$method command $cmd") if $log_cmd;
 		    $commands_run{$cmd} = { object => $self,
 					    method => $method};
 		    $? = $command_status{$cmd} || 0;
-		    return $desired_outputs{$cmd};
+            if (exists($desired_outputs{$cmd})) {
+              return $desired_outputs{$cmd};
+            } else {
+              diag("$method no desired output for cmd $cmd") if $log_cmd_missing;
+              return ""; # always return something, like LC:Process does
+            };
 		});
 }
 


### PR DESCRIPTION
To log all mocked commands that are called via CAF::Process, do

```
use Test::Quattor;
$Test::Quattor::log_cmd=1;
```

To log all mocked commands that are called via CAF::Process (t)output, do

```
use Test::Quattor;
$Test::Quattor::log_cmd_missing=1;
```

This also fixes a bug that the mocked (t)output should return at least an empty string.
