### PR TITLE
Disable default source filter delimiters

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -134,6 +134,7 @@
                   <delimiters>
                     <delimiter>${*}</delimiter>
                   </delimiters>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
                   <outputDirectory>${project.build.directory}/pan/</outputDirectory>
                   <resources>
                     <resource>
@@ -155,6 +156,7 @@
                   <delimiters>
                     <delimiter>${*}</delimiter>
                   </delimiters>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
                   <outputDirectory>${project.build.directory}/lib/perl/NCM/Component</outputDirectory>
                   <resources>
                     <resource>
@@ -179,6 +181,7 @@
                   <delimiters>
                     <delimiter>${*}</delimiter>
                   </delimiters>
+                  <useDefaultDelimiters>false</useDefaultDelimiters>
                   <outputDirectory>${project.build.directory}/doc/pod/NCM/Component</outputDirectory>
                   <resources>
                     <resource>


### PR DESCRIPTION
We were using Maven's default delimiters for filtering (i.e, interpolating variables in the compiled artifacts), which give a special meaning to the @ sign.  This broke especially processing of Pan annotations.

Fixes #11
