### PR TITLE
Pass extra options to prove on the command line.

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -27,7 +27,7 @@
     <release.url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-releases</release.url>
     <snapshot.url>http://stratuslab-srv01.lal.in2p3.fr:8081/content/repositories/quattor-snapshots/</snapshot.url>
     <man.page.dir>/usr/share/man</man.page.dir>
-    <prove.args/>
+    <prove.args>-q</prove.args>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
When invoking the build process with -Dprove.args=-v we'll be able to see all the log messages spit during our tests.

I haven't found any easy way to pass multiple options, or to have conditional properties (other than adding yet another profile to our messy POMs).
