### PR TITLE
bin.xml assembly changes/improvements:

### DIFF
--- a/assemblies/src/main/assembly/bin.xml
+++ b/assemblies/src/main/assembly/bin.xml
@@ -21,17 +21,42 @@
 
     <fileSet>
       <directory>target/lib</directory>
-      <outputDirectory>lib</outputDirectory>
+      <outputDirectory>usr/lib</outputDirectory>
+    </fileSet>
+
+    <fileSet>
+      <directory>target/etc</directory>
+      <outputDirectory>etc</outputDirectory>
+    </fileSet>
+
+    <fileSet>
+      <directory>target/daemon</directory>
+      <outputDirectory>etc/init.d</outputDirectory>
+    </fileSet>
+
+    <fileSet>
+      <directory>target/sbin</directory>
+      <outputDirectory>usr/sbin</outputDirectory>
+    </fileSet>
+
+    <fileSet>
+      <directory>target/bin</directory>
+      <outputDirectory>usr/bin</outputDirectory>
+    </fileSet>
+
+    <fileSet>
+      <directory>target/quattor</directory>
+      <outputDirectory>usr/quattor</outputDirectory>
     </fileSet>
 
     <fileSet>
       <directory>target/pan</directory>
-      <outputDirectory>share/doc/pan</outputDirectory>
+      <outputDirectory>usr/share/doc/pan</outputDirectory>
     </fileSet>
 
     <fileSet>
       <directory>target/doc/man</directory>
-      <outputDirectory>share/man</outputDirectory>
+      <outputDirectory>usr/share/man</outputDirectory>
     </fileSet>
 
   </fileSets>


### PR DESCRIPTION
- add more directories (etc, daemon, doc/man, quattor, sbin, bin): see commit log
- Make the paths in the tar file relative to / to allow to include /etc

This change is needed for the tar file to be useful with something else than configuration modules. For components like `ncm-cdispd`, `ncm-ncd` the tar file is missing the main pieces... Also daemons tend to need some configuration in `/etc`, something not possible with the current `bin.xml` assembly as paths in the tar file were related to `/usr`.
