### PR TITLE
Allow to choose the CAF::Service variant

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -548,7 +548,7 @@ Linux SysV, e.g, C</sbin/service foo start>
 
 Linux, Systemd variant.
 
-=item * C<linux_solaris>
+=item * C<solaris>
 
 Solaris and SMF variant.
 


### PR DESCRIPTION
Redo #18, which disappeared for unknown reasons
