### PR TITLE
build-profile (parent pom): define panc-maven-plugin version to use (10.2)

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -178,6 +178,7 @@
           <plugin>
             <groupId>org.quattor.pan</groupId>
             <artifactId>panc-maven-plugin</artifactId>
+            <version>10.2</version>
             <executions>
               <execution>
                 <id>check-generated-pan-syntax</id>


### PR DESCRIPTION
This a PR redoing #29 after the mistake done merging #27 where https://github.com/quattor/maven-tools master branch was reset to its state at the beginning of 14.12 cycle...
