### PR TITLE
Improve build tools documentation

### DIFF
--- a/BUILD_INFO
+++ b/BUILD_INFO
@@ -19,7 +19,8 @@ $ mvn '-P!cfg-module-dist' '-P!cfg-module-rpm' \
       -Darguments="-P\!cfg-module-dist -P\!cfg-module-rpm '-P!module-test'" \
       release:perform
 
-The backslashes are important to avoid shell expansion of the history. 
+The backslashes are important to avoid shell expansion of the history: unfortunately it
+requires using bash and doesn't work with csh/tcsh. 
 
 '-P!module-test' disable unit tests in build-profile even if PERL5LIB is defined
 (build-profile delivers a parent pom for other Quattor projects: unit tests

--- a/BUILD_INFO
+++ b/BUILD_INFO
@@ -1,5 +1,5 @@
-
-BUILD INFO:
+BUILD INFO
+----------
 
 To build this project, three profiles must be explicitly deactivated.
 These are associated with the standard build pom, but we need to make
@@ -41,3 +41,21 @@ your SourceForge password as well as the GPG key password.
 
 You will probably also need to use the -Dusername=XXX property if your
 account username is not the same as on SourceForge.
+
+
+UPDATING BUILD TOOLS VERSION USED BY OTHER COMPONENTS
+-----------------------------------------------------
+
+The version of the build tools used by other Quattor components is defined in the
+pom.xml of the component (for Quattor configuration modules, in the pom.xml of
+each configuration module), as part of the '<parent>' information.
+
+To update the version used for a given component, check out its repository and
+in the top-level directory, execute the following command:
+
+mvn versions:update-parent
+
+For Quattor configuration modules, this will update the build tools version used
+by all configuration modules in the repository, when run in the top-level directory.
+
+

--- a/BUILD_INFO.md
+++ b/BUILD_INFO.md
@@ -23,8 +23,7 @@ $ mvn -P\!cfg-module-dist -P\!cfg-module-rpm \
       release:perform
 ```
 
-The backslashes are important to avoid shell expansion of the history: unfortunately it
-requires using bash and doesn't work with csh/tcsh. 
+The backslashes are important to avoid shell expansion of the history.
 
 '-P!module-test' disable unit tests in build-profile even if PERL5LIB is defined
 (build-profile delivers a parent pom for other Quattor projects: unit tests

--- a/BUILD_INFO.md
+++ b/BUILD_INFO.md
@@ -7,10 +7,13 @@ sure that they aren't executed here.
 
 Use the following command options:
 
+```bash
 $ mvn '-P!cfg-module-dist' '-P!cfg-module-rpm' '-P!module-test' <goal> [goal...]
+```
 
 To perform a release, do the following:
 
+```bash
 $ mvn '-P!cfg-module-dist' '-P!cfg-module-rpm' \
       -Darguments="-P\!cfg-module-dist -P\!cfg-module-rpm '-P!module-test'" \
       clean release:prepare
@@ -18,6 +21,7 @@ $ mvn '-P!cfg-module-dist' '-P!cfg-module-rpm' \
 $ mvn '-P!cfg-module-dist' '-P!cfg-module-rpm' \
       -Darguments="-P\!cfg-module-dist -P\!cfg-module-rpm '-P!module-test'" \
       release:perform
+```
 
 The backslashes are important to avoid shell expansion of the history: unfortunately it
 requires using bash and doesn't work with csh/tcsh. 
@@ -28,7 +32,9 @@ don't make sense in this context). This allows to run unit tests in other module
 
 To run unit tests in build-scripts only, without building other modules, use:
 
+```bash
 $ mvn -pl build-scripts test
+```
 
 When modifying maven build tools, it is possible to test a version snapshot without
 making a release. To do this, use the 'install' goal that will put the snapshot
@@ -53,7 +59,9 @@ each configuration module), as part of the '<parent>' information.
 To update the version used for a given component, check out its repository and
 in the top-level directory, execute the following command:
 
+```bash
 mvn versions:update-parent
+```
 
 For Quattor configuration modules, this will update the build tools version used
 by all configuration modules in the repository, when run in the top-level directory.

--- a/BUILD_INFO.md
+++ b/BUILD_INFO.md
@@ -8,8 +8,14 @@ sure that they aren't executed here.
 Use the following command options:
 
 ```bash
-$ mvn -P\!cfg-module-dist -P\!cfg-module-rpm -P\!module-test <goal> [goal...]
+$ mvn -P\!cfg-module-dist -P\!cfg-module-rpm -P\!module-test <phase>
 ```
+
+Note that the three main phases that really make sense for the build tools are
+`package`, `integration-test` and `install`. In particular the phase `test` is 
+generally expected to fail in `build-profile` if you have not run `install` before 
+as there is a chicken-and-egg issue: `build-profile` component requires the other
+components built as part of this command. Use `integration-test` rather than `test`.
 
 To perform a release, do the following:
 
@@ -66,4 +72,28 @@ mvn versions:update-parent
 For Quattor configuration modules, this will update the build tools version used
 by all configuration modules in the repository, when run in the top-level directory.
 
+
+UNDERSTANDING Maven
+-------------------
+
+Maven is a powerful and extensible build tool. The build process is driven by file
+`pom.xml` that can look complex... One important concept behind Maven is the
+*build lifecyle* that is an ordered list of phase, namely:
+
+ * validate: validate the project is correct and all necessary information is available
+ * compile: compile the source code of the project
+ * test: test the compiled source code using a suitable unit testing framework. These tests should not require the code be packaged or deployed
+ * package: take the compiled code and package it in its distributable format, such as a JAR.
+ * integration-test: process and deploy the package if necessary into an environment where integration tests can be run
+ * verify: run any checks to verify the package is valid and meets quality criteria
+ * install: install the package into the local repository, for use as a dependency in other projects locally
+
+Specifying one of these phases imply execution of all the previous ones. There is an additional phase, `clean`, that
+can be used with any other phase. It must be specified before any other phase and will remove all the files that could
+have been produced by a previous Maven run.
+
+Before doing any modifications in the `pom.xml`
+files, particularly in this repository, be sure to understand Maven basics.
+Fortunately, there is a lot of documentation available on the web about Maven. A good
+starting point is http://maven.apache.org/guides/getting-started/maven-in-five-minutes.html.
 

--- a/BUILD_INFO.md
+++ b/BUILD_INFO.md
@@ -8,18 +8,18 @@ sure that they aren't executed here.
 Use the following command options:
 
 ```bash
-$ mvn '-P!cfg-module-dist' '-P!cfg-module-rpm' '-P!module-test' <goal> [goal...]
+$ mvn -P\!cfg-module-dist -P\!cfg-module-rpm -P\!module-test <goal> [goal...]
 ```
 
 To perform a release, do the following:
 
 ```bash
-$ mvn '-P!cfg-module-dist' '-P!cfg-module-rpm' \
-      -Darguments="-P\!cfg-module-dist -P\!cfg-module-rpm '-P!module-test'" \
+$ mvn -P\!cfg-module-dist -P\!cfg-module-rpm \
+      -Darguments="-P\!cfg-module-dist -P\!cfg-module-rpm -P\!module-test" \
       clean release:prepare
 
-$ mvn '-P!cfg-module-dist' '-P!cfg-module-rpm' \
-      -Darguments="-P\!cfg-module-dist -P\!cfg-module-rpm '-P!module-test'" \
+$ mvn -P\!cfg-module-dist -P\!cfg-module-rpm \
+      -Darguments="-P\!cfg-module-dist -P\!cfg-module-rpm -P\!module-test" \
       release:perform
 ```
 

--- a/BUILD_INFO.md
+++ b/BUILD_INFO.md
@@ -56,8 +56,9 @@ The version of the build tools used by other Quattor components is defined in th
 pom.xml of the component (for Quattor configuration modules, in the pom.xml of
 each configuration module), as part of the '<parent>' information.
 
-To update the version used for a given component, check out its repository and
-in the top-level directory, execute the following command:
+To update the version used for a given component to the last release available, 
+check out its repository and in the top-level directory, execute the following 
+command:
 
 ```bash
 mvn versions:update-parent

--- a/README.md
+++ b/README.md
@@ -3,3 +3,6 @@ Quattor modules.
 
 Just run `mvn <goal>` in any of your working copies and you'll get the
 correct version of these build tools installed.
+
+To test and build a new release of the build tools or to update the
+version used by other Quattor components, see file BUILD_INFO.


### PR DESCRIPTION
`BULD_INFO` file referenced in README.md and contents enhanced to:
- Make explicit that building a maven tools release require using bash
- Document how to update the version used by other components