### PR TITLE
Support template unittesting through controlled failure of compilations

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -65,6 +65,14 @@ use Test::Quattor::ProfileCache qw(prepare_profile_cache get_config_for_profile)
 
 =over
 
+=item * QUATTOR_TEST_LOG_DEBUGLEVEL
+
+If the environment variable QUATTOR_TEST_LOG_DEBUGLEVEL is set, the unittests
+will run with this debuglevel (0-5). Otherwise the default loglevel is 'verbose'.
+
+To actually see the verbose or debug output, you need to run prove with verbose flag
+(e.g. by passing C<-Dprove.args=-v> or by setting C<-v> in the C<<~/.proverc>>).
+
 =item * C<$log_cmd>
 
 A boolean to enable logging of each command that is run via CAF::Process.
@@ -184,7 +192,16 @@ our @EXPORT = qw(get_command set_file_contents get_file set_desired_output
                  command_history_reset command_history_ok set_service_variant
                  set_caf_file_close_diff);
 
-$main::this_app = CAF::Application->new('a', "--verbose", @ARGV);
+my @logopts = qw(--verbose);
+my $debuglevel = $ENV{QUATTOR_TEST_LOG_DEBUGLEVEL};
+if (defined($debuglevel)) {
+  if ($debuglevel !~ m/^[0-5]$/) {
+    $debuglevel = 0;
+  }
+  push(@logopts, '--debug', $debuglevel);
+}
+$main::this_app = CAF::Application->new('a', @logopts, @ARGV);
+$main::this_app->verbose("Log options ", join(" ", @logopts));
 
 # Modules that will have some methods mocked. These must be globals,
 # or the test script and component will see the original, unmocked

--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -309,6 +309,12 @@ sub new_filewriter_open
     $files_contents{$fn} = $f;
 
     $files_contents{*$f->{filename}} = $f;
+
+    *$f->{_mocked} = {
+                     iostring => $iostring,
+                     filewriter => $filewriter,
+                    };
+
     return $f;
 }
 
@@ -357,6 +363,9 @@ sub new_fileeditor_open
 
     my $f = CAF::FileWriter::new(@_);
     $f->set_contents($desired_file_contents{*$f->{filename}});
+
+    *$f->{_mocked}->{fileeditor} = $fileeditor;
+
     return $f;
 }
 

--- a/build-scripts/src/main/perl/Test/Quattor/Object.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Object.pm
@@ -1,5 +1,5 @@
 # ${license-info}
-# ${developer-info
+# ${developer-info}
 # ${author-info}
 # ${build-info}
 

--- a/build-scripts/src/main/perl/Test/Quattor/Object.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Object.pm
@@ -8,12 +8,23 @@ use warnings;
 
 package Test::Quattor::Object;
 
+use base 'Exporter';
+
 our @ISA;
 use Test::More;
 
 use File::Basename;
 use File::Find;
-use Cwd 'abs_path';
+use Cwd qw(abs_path getcwd);
+use File::Path qw(mkpath);
+
+use Readonly;
+
+# The target pan directory used by maven to stage the 
+# to-be-distributed pan templates 
+Readonly our $TARGET_PAN_RELPATH => 'target/pan';
+
+our @EXPORT = qw($TARGET_PAN_RELPATH make_target_pan_path);
 
 sub new
 {
@@ -266,6 +277,26 @@ sub get_template_library_core
         }
     }
     return $tlc;
+}
+
+=pod
+
+=head2 make_target_pan_path
+
+Create if needed the "target/pan" path in the current directory, and returns the 
+absolute pathname.
+
+=cut
+
+sub make_target_pan_path
+{
+    # Always add the TARGET_PAN_RELPATH to the includepath of the compilation
+    my $dest = getcwd() . "/$TARGET_PAN_RELPATH";
+    if (!-d $dest) {
+        mkpath($dest)
+    }
+
+    return $dest;
 }
 
 1;

--- a/build-scripts/src/main/perl/Test/Quattor/Object.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Object.pm
@@ -24,7 +24,7 @@ use Readonly;
 # to-be-distributed pan templates 
 Readonly our $TARGET_PAN_RELPATH => 'target/pan';
 
-our @EXPORT = qw($TARGET_PAN_RELPATH make_target_pan_path);
+our @EXPORT = qw($TARGET_PAN_RELPATH);
 
 sub new
 {
@@ -250,9 +250,15 @@ sub get_template_library_core
     $notok_on_missing = 1 if (! defined($notok_on_missing));
 
     my $tlc = $ENV{QUATTOR_TEST_TEMPLATE_LIBRARY_CORE};
-    if ($tlc && -d $tlc) {
-        $self->verbose(
-            "template-library-core path $tlc set via QUATTOR_TEST_TEMPLATE_LIBRARY_CORE");
+    if ($tlc) {
+        my $msg = "template-library-core path $tlc set via QUATTOR_TEST_TEMPLATE_LIBRARY_CORE";
+        if (-d $tlc) {
+            $self->verbose($msg);
+        } else {
+            # Log it
+            $self->info("$msg, but it is not a directory.");
+            $tlc = undef;
+        }
     } else {
 
         # TODO: better guess?
@@ -262,7 +268,10 @@ sub get_template_library_core
         } elsif (-d "../$d") {
             $tlc = "../$d";
         } else {
-            $self->error("no more guesses for template-library-core path");
+            $self->error("no more guesses for template-library-core path: tlc ",
+                         $tlc ? $tlc : "");
+            # Force it undef
+            $tlc = undef;
         }
     }
     if ($tlc) {
@@ -290,6 +299,8 @@ absolute pathname.
 
 sub make_target_pan_path
 {
+    my $self = shift;
+
     # Always add the TARGET_PAN_RELPATH to the includepath of the compilation
     my $dest = getcwd() . "/$TARGET_PAN_RELPATH";
     if (!-d $dest) {

--- a/build-scripts/src/main/perl/Test/Quattor/Object.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Object.pm
@@ -35,9 +35,9 @@ sub _initialize
 
 =pod
 
-=head2 info    
+=head2 info
 
-info-type logger, calls diag. 
+info-type logger, calls diag.
 Arguments are converted in message, prefixed with 'INFO'.
 
 =cut
@@ -132,17 +132,17 @@ sub notok
     ok(0, $msg);
 }
 
-=pod 
+=pod
 
 =head2 gather_pan
 
 Walk the C<panpath> and gather all pan templates.
 
-A pan template is a text file with an C<.pan> extension; 
-they are considered 'invalid' when the C<pannamespace> is not 
+A pan template is a text file with an C<.pan> extension;
+they are considered 'invalid' when the C<pannamespace> is not
 correct.
 
-Returns a reference to hash with key path 
+Returns a reference to hash with key path
 (relative to C<relpath>) and value hashreference
 with 'type' of pan templates and 'expected' relative filepath;
 and an arrayreference to the invalid pan templates.
@@ -212,6 +212,60 @@ sub gather_pan
     }, $panpath);
 
     return \%pans, \@invalid_pans;
+}
+
+=pod
+
+=head2 get_template_library_core
+
+Return path to C<template-library-core> to allow "include 'pan/types';"
+and friends being used in the templates (in particular the schema).
+
+By default, the C<template-library-core> is expected to be in the
+parent or parent of parent directory as the current working directory.
+
+One can also specify the location via the C<QUATTOR_TEST_TEMPLATE_LIBRARY_CORE>
+environment variable.
+
+When C<notok_on_missing> is true (or undefined), C<notok> is called (i.e. test fails).
+
+=cut
+
+sub get_template_library_core
+{
+    # only for logging
+    my ($self, $notok_on_missing) = @_;
+
+    $notok_on_missing = 1 if (! defined($notok_on_missing));
+
+    my $tlc = $ENV{QUATTOR_TEST_TEMPLATE_LIBRARY_CORE};
+    if ($tlc && -d $tlc) {
+        $self->verbose(
+            "template-library-core path $tlc set via QUATTOR_TEST_TEMPLATE_LIBRARY_CORE");
+    } else {
+
+        # TODO: better guess?
+        my $d = "../template-library-core";
+        if (-d $d) {
+            $tlc = $d;
+        } elsif (-d "../$d") {
+            $tlc = "../$d";
+        } else {
+            $self->error("no more guesses for template-library-core path");
+        }
+    }
+    if ($tlc) {
+        $tlc = abs_path($tlc);
+        $self->verbose("template-library-core path found $tlc");
+    } else {
+        my $msg = "No template-library-core path found (set QUATTOR_TEST_TEMPLATE_LIBRARY_CORE?)";
+        if($notok_on_missing) {
+            $self->notok($msg);
+        } else {
+            $self->info($msg);
+        }
+    }
+    return $tlc;
 }
 
 1;

--- a/build-scripts/src/main/perl/Test/Quattor/Panc.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Panc.pm
@@ -128,12 +128,17 @@ sub get_panc_includepath
 Compile the pan C<profile> (file 'C<profile>.pan' in C<resourcesdir>)
 and create the profile in C<outputdir>.
 
+If C<croak_on_error> is true (or undef), the method croaks on compilation failure.
+If false, it will return the exitcode.
+
 =cut
 
 sub panc
 {
 
-    my ($profile, $resourcesdir, $outputdir) = @_;
+    my ($profile, $resourcesdir, $outputdir, $croak_on_error) = @_;
+
+    $croak_on_error = 1 if (! defined($croak_on_error));
 
     if( ! -d $outputdir) {
         mkpath($outputdir)
@@ -167,15 +172,22 @@ sub panc
     } else {
         $proc->execute();
     };
+    chdir($currentdir);
 
-    my $pancmsg = "Pan compiler called with: $proc from directory ".getcwd();
+    my $pancmsg = "Pan compiler called with: $proc from directory $resourcesdir";
     if($?) {
-        my $msg = "Unable to compile profile $profile. Minimal panc version is $PANC_MINIMAL";
-        croak("$msg. $pancmsg with output\n$output");
+        my $msg = "Unable to compile profile $profile. Minimal panc version is $PANC_MINIMAL. ";
+        $msg .= "$pancmsg with output\n$output";
+        if($croak_on_error) {
+            croak($msg);
+        } else {
+            diag($msg);
+        }
     } else {
         note($pancmsg);
     }
-    chdir($currentdir);
+
+    return $?;
 };
 
 

--- a/build-scripts/src/main/perl/Test/Quattor/Panc.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Panc.pm
@@ -1,3 +1,8 @@
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
 use strict;
 use warnings;
 

--- a/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
@@ -1,3 +1,8 @@
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
 use strict;
 use warnings;
 
@@ -13,6 +18,8 @@ use Carp qw(carp croak);
 use File::Path qw(mkpath);
 use Cwd qw(getcwd);
 
+use Test::Quattor::Object qw(make_target_pan_path);
+
 use Test::Quattor::Panc qw(panc set_panc_includepath get_panc_includepath);
 
 use EDG::WP4::CCM::Configuration;
@@ -21,10 +28,6 @@ use EDG::WP4::CCM::Fetch;
 use EDG::WP4::CCM::Element qw(escape unescape);
 
 use Readonly;
-
-# The target pan directory used by maven to stage the 
-# to-be-distributed pan templates 
-Readonly our $TARGET_PAN_RELPATH => 'target/pan';
 
 Readonly::Hash my %DEFAULT_PROFILE_CACHE_DIRS => {
     resources => "src/test/resources",
@@ -42,7 +45,7 @@ retrieve_retries 1
 EOF
 
 our @EXPORT = qw(get_config_for_profile prepare_profile_cache
-                 set_profile_cache_options $TARGET_PAN_RELPATH);
+                 set_profile_cache_options);
 
 =pod
 
@@ -167,11 +170,7 @@ sub prepare_profile_cache
     print $fh "1\n";
     $fh->close();
 
-    # Always add the TARGET_PAN_RELPATH to the includepath of the compilation
-    my $dest = getcwd() . "/$TARGET_PAN_RELPATH";
-    if (!-d $dest) {
-        mkpath($dest)
-    }
+    my $dest = make_target_pan_path();
     my $incdirs = get_panc_includepath();
     # Always add the current dir
     push(@$incdirs, '.') if (! (grep { $_ eq '.'} @$incdirs));

--- a/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
@@ -44,7 +44,8 @@ retrieve_retries 1
 EOF
 
 our @EXPORT = qw(get_config_for_profile prepare_profile_cache
-                 set_profile_cache_options);
+                 set_profile_cache_options
+                 prepare_profile_cache_panc_includedirs);
 
 
 # A Test::Quattor::Object instance, can be used as logger.
@@ -55,7 +56,7 @@ my $object = Test::Quattor::Object->new();
 
 =head1 DESCRIPTION
 
-Module to setup a profile cache 
+Module to setup a profile cache
 
 =cut
 
@@ -74,7 +75,7 @@ Will be used by C<get_profile_cache_dirs>
 
 =item cache
 
-=item resources 
+=item resources
 
 =item profiles
 
@@ -101,7 +102,7 @@ the profile cache: 'cache', 'resources' and 'profiles'.
 The values are generated from the defaults or C<profilecacheoptions>
 (to be set via C<set_profile_cache_options>).
 
-Relative paths are assumed to be relative wrt current directory; 
+Relative paths are assumed to be relative wrt current directory;
 absolute paths are used for the returned values.
 
 =cut
@@ -119,7 +120,7 @@ sub get_profile_cache_dirs
         $dir = "$currentdir/$dir" if ($dir !~ m/^\//);
         $dirs{$type} = $dir;
     }
-    
+
     return \%dirs;
 }
 
@@ -127,17 +128,40 @@ sub get_profile_cache_dirs
 sub profile_cache_name
 {
     my ($profile) = @_;
-    
+
     my $dirs = get_profile_cache_dirs();
     my $cachename = $profile;
-    $cachename =~ s/\.pan$//; 
+    $cachename =~ s/\.pan$//;
     $cachename =~ s/^$dirs->{resources}\/+//;
     $cachename = escape($cachename);
-    
+
     note("Converted profile $profile in cache name $cachename") if ($profile ne $cachename);
 
     return $cachename;
-    
+
+}
+
+=pod
+
+=head2 prepare_profile_cache_panc_includedirs
+
+=cut
+
+sub prepare_profile_cache_panc_includedirs
+{
+    my $dest = $object->make_target_pan_path();
+    my $incdirs = get_panc_includepath();
+    # Always add the current dir
+    push(@$incdirs, '.') if (! (grep { $_ eq '.' } @$incdirs));
+    push(@$incdirs, $dest) if (! (grep { $_ eq $dest } @$incdirs));
+
+    # no failed test on missing template library core
+    # to avoid issues with auto-detect, set the QUATTOR_TEST_TEMPLATE_LIBRARY_CORE
+    # to non-existinig dir. (This is not supposed to cause any issues though)
+    my $tlc = $object->get_template_library_core(0);
+    push(@$incdirs, $tlc) if ($tlc && ! (grep { $_ eq $tlc } @$incdirs));
+
+    set_panc_includepath(@$incdirs);
 }
 
 =pod
@@ -150,11 +174,15 @@ wherever the CCM configuration tells us.
 
 Returns the configuration object for this profile.
 
+The C<croak_on_error> argument is passed to the C<Test::Quattor::Panc::panc> method.
+If this boolean is 0 (and not undef), C<prepare_profile_cache>
+will return the C<panc> exitcode upon C<panc> failure.
+
 =cut
 
 sub prepare_profile_cache
 {
-    my ($profile) = @_;
+    my ($profile, $croak_on_error) = @_;
 
     my $dirs = get_profile_cache_dirs();
 
@@ -174,24 +202,14 @@ sub prepare_profile_cache
     print $fh "1\n";
     $fh->close();
 
-    my $dest = $object->make_target_pan_path();
-    my $incdirs = get_panc_includepath();
-    # Always add the current dir
-    push(@$incdirs, '.') if (! (grep { $_ eq '.' } @$incdirs));
-    push(@$incdirs, $dest) if (! (grep { $_ eq $dest } @$incdirs));
-
-    # no failed test on missing template library core
-    # to avoid issues with auto-detect, set the QUATTOR_TEST_TEMPLATE_LIBRARY_CORE 
-    # to non-existinig dir. (This is not supposed to cause any issues though)
-    my $tlc = $object->get_template_library_core(0);
-    push(@$incdirs, $tlc) if ($tlc && ! (grep { $_ eq $tlc } @$incdirs));
-
-    set_panc_includepath(@$incdirs);
+    prepare_profile_cache_panc_includedirs();
 
     # Compile profiles
-    panc($profile, $dirs->{resources}, $dirs->{profiles});
+    my $ec = panc($profile, $dirs->{resources}, $dirs->{profiles}, $croak_on_error);
+    # on failure, there's nothing to do any further.
+    return $ec if($ec);
 
-    # Support non-existing ccm.cfg 
+    # Support non-existing ccm.cfg
     # (also prevents having to ship same file over and over again)
     my $ccmconfig = "$dirs->{resources}/ccm.cfg";
     if( ! -f $ccmconfig) {
@@ -218,7 +236,7 @@ sub prepare_profile_cache
 
     my $cm =  EDG::WP4::CCM::CacheManager->new($cache);
     $configs{$cachename} = $cm->getUnlockedConfiguration();
-    
+
     return $configs{$cachename};
 }
 

--- a/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
@@ -18,8 +18,7 @@ use Carp qw(carp croak);
 use File::Path qw(mkpath);
 use Cwd qw(getcwd);
 
-use Test::Quattor::Object qw(make_target_pan_path);
-
+use Test::Quattor::Object;
 use Test::Quattor::Panc qw(panc set_panc_includepath get_panc_includepath);
 
 use EDG::WP4::CCM::Configuration;
@@ -46,6 +45,11 @@ EOF
 
 our @EXPORT = qw(get_config_for_profile prepare_profile_cache
                  set_profile_cache_options);
+
+
+# A Test::Quattor::Object instance, can be used as logger.
+my $object = Test::Quattor::Object->new();
+
 
 =pod
 
@@ -170,11 +174,18 @@ sub prepare_profile_cache
     print $fh "1\n";
     $fh->close();
 
-    my $dest = make_target_pan_path();
+    my $dest = $object->make_target_pan_path();
     my $incdirs = get_panc_includepath();
     # Always add the current dir
-    push(@$incdirs, '.') if (! (grep { $_ eq '.'} @$incdirs));
-    push(@$incdirs, $dest) if (! (grep { $_ eq $dest} @$incdirs));
+    push(@$incdirs, '.') if (! (grep { $_ eq '.' } @$incdirs));
+    push(@$incdirs, $dest) if (! (grep { $_ eq $dest } @$incdirs));
+
+    # no failed test on missing template library core
+    # to avoid issues with auto-detect, set the QUATTOR_TEST_TEMPLATE_LIBRARY_CORE 
+    # to non-existinig dir. (This is not supposed to cause any issues though)
+    my $tlc = $object->get_template_library_core(0);
+    push(@$incdirs, $tlc) if ($tlc && ! (grep { $_ eq $tlc } @$incdirs));
+
     set_panc_includepath(@$incdirs);
 
     # Compile profiles

--- a/build-scripts/src/main/perl/Test/Quattor/RegexpTest.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/RegexpTest.pm
@@ -1,5 +1,5 @@
 # ${license-info}
-# ${developer-info
+# ${developer-info}
 # ${author-info}
 # ${build-info}
 

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender.pm
@@ -1,5 +1,5 @@
 # ${license-info}
-# ${developer-info
+# ${developer-info}
 # ${author-info}
 # ${build-info}
 

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
@@ -1,5 +1,5 @@
 # ${license-info}
-# ${developer-info
+# ${developer-info}
 # ${author-info}
 # ${build-info}
 

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
@@ -22,55 +22,10 @@ use base qw(Test::Quattor::TextRender);
 =head1 NAME
 
 Test::Quattor::TextRender::Base - Base class for unittesting 
-the templates in nmc-metaocnifg and components.
+the templates in ncm-metaconfig and components.
 
 Refer to the specialized Test::Quattor::TextRender::Metaconfig and 
 Test::Quattor::TextRender::Component for actual usage.
-
-=head2 get_template_library_core
-
-Return path to template-library-core to allow "include 'pan/types';" 
-and friends being used in the templates (in particular the schema).
-
-By default, the C<template-library-core> is expected to be in the 
-same directory as the one this test is being ran from.
-One can also specify the location via the C<QUATTOR_TEST_TEMPLATE_LIBRARY_CORE> 
-environment variable.
-
-=cut
-
-sub get_template_library_core
-{
-    # only for logging
-    my $self = shift;
-
-    my $tlc = $ENV{QUATTOR_TEST_TEMPLATE_LIBRARY_CORE};
-    if ($tlc && -d $tlc) {
-        $self->verbose(
-            "template-library-core path $tlc set via QUATTOR_TEST_TEMPLATE_LIBRARY_CORE");
-    } else {
-
-        # TODO: better guess?
-        my $d = "../template-library-core";
-        if (-d $d) {
-            $tlc = $d;
-        } elsif (-d "../$d") {
-            $tlc = "../$d";
-        } else {
-            $self->error("no more guesses for template-library-core path");
-        }
-    }
-    if ($tlc) {
-        $tlc = abs_path($tlc);
-        $self->verbose("template-library-core path found $tlc");
-    } else {
-        $self->notok(
-            "No template-library-core path found (set QUATTOR_TEST_TEMPLATE_LIBRARY_CORE?)");
-    }
-    return $tlc;
-}
-
-=pod
 
 =head2 test
 
@@ -92,7 +47,7 @@ sub test
 
     # Set panc include dirs
     $self->make_namespace($self->{panpath}, $self->{pannamespace});
-    set_panc_includepath($self->{namespacepath}, $self->get_template_library_core);
+    set_panc_includepath($self->{namespacepath}, $self->get_template_library_core());
 
     my $testspath = $self->{testspath};
     $testspath .= "/$self->{version}" if (exists($self->{version}));

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Component.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Component.pm
@@ -1,5 +1,5 @@
 # ${license-info}
-# ${developer-info
+# ${developer-info}
 # ${author-info}
 # ${build-info}
 

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Metaconfig.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Metaconfig.pm
@@ -1,5 +1,5 @@
 # ${license-info}
-# ${developer-info
+# ${developer-info}
 # ${author-info}
 # ${build-info}
 

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Metaconfig.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Metaconfig.pm
@@ -14,8 +14,6 @@ use Test::More;
 use File::Path qw(mkpath);
 use Cwd qw(getcwd);
 
-use Test::Quattor::Object qw(make_target_pan_path);
-
 use base qw(Test::Quattor::TextRender::Base);
 
 =pod
@@ -98,7 +96,7 @@ sub _initialize
     $self->{pannamespace} = "metaconfig/$self->{service}";
 
     if (!$self->{namespacepath}) {
-        $self->{namespacepath} = make_target_pan_path();
+        $self->{namespacepath} = $self->make_target_pan_path();
     }
 
     # Fix TextRender relpath and includepath

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Metaconfig.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Metaconfig.pm
@@ -14,7 +14,7 @@ use Test::More;
 use File::Path qw(mkpath);
 use Cwd qw(getcwd);
 
-use Test::Quattor::ProfileCache qw($TARGET_PAN_RELPATH);
+use Test::Quattor::Object qw(make_target_pan_path);
 
 use base qw(Test::Quattor::TextRender::Base);
 
@@ -98,11 +98,7 @@ sub _initialize
     $self->{pannamespace} = "metaconfig/$self->{service}";
 
     if (!$self->{namespacepath}) {
-        my $dest = getcwd() . "/$TARGET_PAN_RELPATH";
-        if (!-d $dest) {
-            mkpath($dest)
-        }
-        $self->{namespacepath} = $dest;
+        $self->{namespacepath} = make_target_pan_path();
     }
 
     # Fix TextRender relpath and includepath

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/RegexpTest.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/RegexpTest.pm
@@ -1,5 +1,5 @@
 # ${license-info}
-# ${developer-info
+# ${developer-info}
 # ${author-info}
 # ${build-info}
 

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Suite.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Suite.pm
@@ -1,5 +1,5 @@
 # ${license-info}
-# ${developer-info
+# ${developer-info}
 # ${author-info}
 # ${build-info}
 

--- a/build-scripts/src/test/perl/profilecache.t
+++ b/build-scripts/src/test/perl/profilecache.t
@@ -38,9 +38,9 @@ is($TARGET_PAN_RELPATH, 'target/pan', 'TARGET_PAN_RELPATH is exported');
 my $dest = getcwd() . "/$TARGET_PAN_RELPATH";
 ok(-d $dest, "$TARGET_PAN_RELPATH directory exists");
 my $includedir = get_panc_includepath();
-ok(grep {$_ eq $dest} @$includedir, "the $TARGET_PAN_RELPATH directory is in panc includepath");
-ok(grep {$_ eq '.'} @$includedir, "the '.' directory is in panc includepath");
-ok(grep {$_ eq $tmp_tlc_dir} @$includedir, "the QUATTOR_TEST_TEMPLATE_LIBRARY_CORE directory is in panc includepath");
+ok((grep {$_ eq $dest} @$includedir), "the $TARGET_PAN_RELPATH directory is in panc includepath");
+ok((grep {$_ eq '.'} @$includedir), "the '.' directory is in panc includepath");
+ok((grep {$_ eq $tmp_tlc_dir} @$includedir), "the QUATTOR_TEST_TEMPLATE_LIBRARY_CORE directory is in panc includepath");
 
 my $cfg2 = get_config_for_profile('profilecache');
 is_deeply($cfg, $cfg2, 

--- a/build-scripts/src/test/perl/profilecache.t
+++ b/build-scripts/src/test/perl/profilecache.t
@@ -8,10 +8,10 @@ use Cwd;
 use EDG::WP4::CCM::Element qw(escape);
 
 use Test::Quattor::ProfileCache qw(prepare_profile_cache 
-    get_config_for_profile set_profile_cache_options 
-    $TARGET_PAN_RELPATH);
+    get_config_for_profile set_profile_cache_options);
+use Test::Quattor::Object qw($TARGET_PAN_RELPATH);
 use Test::Quattor::Panc qw(get_panc_includepath);
-use Cwd;
+use Cwd qw(getcwd);
 
 
 # Can't have NoAction here, since no CAF mocking happens
@@ -72,6 +72,7 @@ my $includedir = get_panc_includepath();
 ok(grep {$_ eq $dest} @$includedir, "the $TARGET_PAN_RELPATH directory is in panc includepath");
 ok(grep {$_ eq '.'} @$includedir, "the '.' directory is in panc includepath");
 
+# Test get_config_for_profile
 my $abscfg2 = get_config_for_profile($profile);
 is_deeply($abscfg, $abscfg2, 
           "get_config_for_profile fecthes same configuration object as returned by prepare_profile_cache for abs profile");

--- a/build-scripts/src/test/perl/profilecache.t
+++ b/build-scripts/src/test/perl/profilecache.t
@@ -7,7 +7,7 @@ use Cwd;
 
 use EDG::WP4::CCM::Element qw(escape);
 
-use Test::Quattor::ProfileCache qw(prepare_profile_cache 
+use Test::Quattor::ProfileCache qw(prepare_profile_cache
     get_config_for_profile set_profile_cache_options);
 use Test::Quattor::Object qw($TARGET_PAN_RELPATH);
 use Test::Quattor::Panc qw(get_panc_includepath);
@@ -26,11 +26,11 @@ $ENV{QUATTOR_TEST_TEMPLATE_LIBRARY_CORE} = $tmp_tlc_dir;
 
 my $cfg = prepare_profile_cache('profilecache');
 
-isa_ok($cfg, "EDG::WP4::CCM::Configuration", 
+isa_ok($cfg, "EDG::WP4::CCM::Configuration",
             "get_config_for_profile returns a EDG::WP4::CCM::Configuration instance");
 
-is_deeply($cfg->getElement("/")->getTree(), 
-            {test => "data"}, 
+is_deeply($cfg->getElement("/")->getTree(),
+            {test => "data"},
             "getTree of root element returns correct hashref");
 
 # there should be a target/pan dir and should be in includepath
@@ -42,8 +42,17 @@ ok((grep {$_ eq $dest} @$includedir), "the $TARGET_PAN_RELPATH directory is in p
 ok((grep {$_ eq '.'} @$includedir), "the '.' directory is in panc includepath");
 ok((grep {$_ eq $tmp_tlc_dir} @$includedir), "the QUATTOR_TEST_TEMPLATE_LIBRARY_CORE directory is in panc includepath");
 
+# test the controlled failure of broken templates
+# this also passes if the file is simply missing
+my $profname = 'profilecache_broken';
+my $absprof = getcwd()."/src/test/resources/$profname.pan";
+ok(-f $absprof, "Broken template $profname exists: $absprof");
+my $ec = prepare_profile_cache($profname, 0);
+ok($ec, "Non-zero exitcode for brokenprofile with croak_on_error set to 0");
+
+
 my $cfg2 = get_config_for_profile('profilecache');
-is_deeply($cfg, $cfg2, 
+is_deeply($cfg, $cfg2,
           "get_config_for_profile fecthes same configuration object as returned by prepare_profile_cache");
 
 # verify defaults; they shouldn't "just" change
@@ -57,13 +66,13 @@ is_deeply($dirs, {
 
 set_profile_cache_options(resources => 'src/test/resources/myresources');
 $dirs = Test::Quattor::ProfileCache::get_profile_cache_dirs();
-is($dirs->{resources}, "$currentdir/src/test/resources/myresources", 
+is($dirs->{resources}, "$currentdir/src/test/resources/myresources",
     "Set and retrieved custom profile_cache resources dir");
 
 # test rename
-is(Test::Quattor::ProfileCache::profile_cache_name("test"), "test", 
+is(Test::Quattor::ProfileCache::profile_cache_name("test"), "test",
     "Profilecache name preserves original behaviour");
-is(Test::Quattor::ProfileCache::profile_cache_name("$dirs->{resources}/subtree/test.pan"), escape("subtree/test"), 
+is(Test::Quattor::ProfileCache::profile_cache_name("$dirs->{resources}/subtree/test.pan"), escape("subtree/test"),
     "Profilecache name handles absolute paths");
 
 
@@ -72,20 +81,19 @@ my $profile = "$dirs->{resources}/absprofilecache.pan";
 ok (-f $profile, "Found profile $profile");
 my $abscfg = prepare_profile_cache($profile);
 
-isa_ok($abscfg, "EDG::WP4::CCM::Configuration", 
+isa_ok($abscfg, "EDG::WP4::CCM::Configuration",
             "get_config_for_profile returns a EDG::WP4::CCM::Configuration instance for abs profile");
 
-is_deeply($abscfg->getElement("/")->getTree(), 
-            {test => "data"}, 
+is_deeply($abscfg->getElement("/")->getTree(),
+            {test => "data"},
             "getTree of root element returns correct hashref for abs profile");
 
 
 
 # Test get_config_for_profile
 my $abscfg2 = get_config_for_profile($profile);
-is_deeply($abscfg, $abscfg2, 
+is_deeply($abscfg, $abscfg2,
           "get_config_for_profile fecthes same configuration object as returned by prepare_profile_cache for abs profile");
-
 
 
 done_testing();

--- a/build-scripts/src/test/perl/profilecache.t
+++ b/build-scripts/src/test/perl/profilecache.t
@@ -12,10 +12,17 @@ use Test::Quattor::ProfileCache qw(prepare_profile_cache
 use Test::Quattor::Object qw($TARGET_PAN_RELPATH);
 use Test::Quattor::Panc qw(get_panc_includepath);
 use Cwd qw(getcwd);
-
+use File::Temp qw(tempdir);
+use File::Path qw(mkpath);
 
 # Can't have NoAction here, since no CAF mocking happens
 # and otherwise nothing would be written
+
+my $target = getcwd()."/target";
+mkpath($target) if ! -d $target;
+my $tmp_tlc_dir = tempdir(DIR => $target);
+
+$ENV{QUATTOR_TEST_TEMPLATE_LIBRARY_CORE} = $tmp_tlc_dir;
 
 my $cfg = prepare_profile_cache('profilecache');
 
@@ -25,6 +32,15 @@ isa_ok($cfg, "EDG::WP4::CCM::Configuration",
 is_deeply($cfg->getElement("/")->getTree(), 
             {test => "data"}, 
             "getTree of root element returns correct hashref");
+
+# there should be a target/pan dir and should be in includepath
+is($TARGET_PAN_RELPATH, 'target/pan', 'TARGET_PAN_RELPATH is exported');
+my $dest = getcwd() . "/$TARGET_PAN_RELPATH";
+ok(-d $dest, "$TARGET_PAN_RELPATH directory exists");
+my $includedir = get_panc_includepath();
+ok(grep {$_ eq $dest} @$includedir, "the $TARGET_PAN_RELPATH directory is in panc includepath");
+ok(grep {$_ eq '.'} @$includedir, "the '.' directory is in panc includepath");
+ok(grep {$_ eq $tmp_tlc_dir} @$includedir, "the QUATTOR_TEST_TEMPLATE_LIBRARY_CORE directory is in panc includepath");
 
 my $cfg2 = get_config_for_profile('profilecache');
 is_deeply($cfg, $cfg2, 
@@ -64,13 +80,6 @@ is_deeply($abscfg->getElement("/")->getTree(),
             "getTree of root element returns correct hashref for abs profile");
 
 
-# there should be a target/pan dir and should be in includepath
-is($TARGET_PAN_RELPATH, 'target/pan', 'TARGET_PAN_RELPATH is exported');
-my $dest = getcwd() . "/$TARGET_PAN_RELPATH";
-ok(-d $dest, "$TARGET_PAN_RELPATH directory exists");
-my $includedir = get_panc_includepath();
-ok(grep {$_ eq $dest} @$includedir, "the $TARGET_PAN_RELPATH directory is in panc includepath");
-ok(grep {$_ eq '.'} @$includedir, "the '.' directory is in panc includepath");
 
 # Test get_config_for_profile
 my $abscfg2 = get_config_for_profile($profile);

--- a/build-scripts/src/test/perl/textrender-suite-2.0.t
+++ b/build-scripts/src/test/perl/textrender-suite-2.0.t
@@ -7,7 +7,7 @@ use Test::Quattor::TextRender;
 use Test::Quattor::TextRender::Suite;
 
 # only use it like this for this particular unittest
-use Test::Quattor::TextRender::Base;
+use Test::Quattor::Object;
 
 use Test::Quattor::Panc qw(set_panc_includepath);
 
@@ -40,7 +40,7 @@ my $st = Test::Quattor::TextRender::Suite->new(
     );
 
 set_panc_includepath($tr->{namespacepath}, 
-    Test::Quattor::TextRender::Base::get_template_library_core($st));
+    Test::Quattor::Object::get_template_library_core($st));
 
 $st->test();
 

--- a/build-scripts/src/test/perl/textrender-suite.t
+++ b/build-scripts/src/test/perl/textrender-suite.t
@@ -7,7 +7,7 @@ use Test::Quattor::TextRender;
 use Test::Quattor::TextRender::Suite;
 
 # only use it like this for this particular unittest
-use Test::Quattor::TextRender::Base;
+use Test::Quattor::Object;
 
 use Test::Quattor::Panc qw(set_panc_includepath);
 
@@ -41,7 +41,7 @@ my $st = Test::Quattor::TextRender::Suite->new(
 
 # get_template_library_core should never be used like this
 set_panc_includepath($tr->{namespacepath}, 
-    Test::Quattor::TextRender::Base::get_template_library_core($st));
+    Test::Quattor::Object::get_template_library_core($st));
 
 isa_ok($st, "Test::Quattor::TextRender::Suite", 
        "Returns Test::Quattor::TextRender::Suite instance for service");

--- a/build-scripts/src/test/resources/profilecache_broken.pan
+++ b/build-scripts/src/test/resources/profilecache_broken.pan
@@ -1,0 +1,1 @@
+Woohoo, panc won't like this.


### PR DESCRIPTION
 Support controlled pan compilation failure through ProfileCache prepare_profile_cache method.
This allows unittesting of failing pan templates (eg to unittest intentional compilation failures due to schema violation).
