### PR TITLE
BUILD_INFO: clarifications after doing 1.42 release

### DIFF
--- a/BUILD_INFO.md
+++ b/BUILD_INFO.md
@@ -53,6 +53,13 @@ command:
 mvn versions:update-parent
 ```
 
+After you have checked that everything is ok, commit the modified pom files and
+remove the backup files created with:
+
+```bash
+git clean -f
+```
+
 For Quattor configuration modules, this will update the build tools version used
 by all configuration modules in the repository, when run in the top-level directory.
 


### PR DESCRIPTION
The goal is to have enough information for an *advanced user* to be able to do a release without the help of one of the previous releaser!