### PR TITLE
Rename Test::Quattor::TextRender::Base mock method to mock_textrender

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
@@ -22,7 +22,7 @@ use Readonly;
 
 Readonly our $TARGET_TT_DIR => "target/share/templates/quattor";
 
-our @EXPORT = qw(mock);
+our @EXPORT = qw(mock_textrender);
 our @EXPORT_OK = qw($TARGET_TT_DIR);
 
 =pod
@@ -78,7 +78,7 @@ sub test
 
 =pod
 
-=head2 mock
+=head2 mock_textrender
 
 An exported function that mocks C<CAF::TextRender>
 to test usage of TT files during regular component use
@@ -95,7 +95,7 @@ staged during testing via maven (use exported C<$TARGET_TT_DIR>).
 To be used as
 
     use Test::Quattor::TextRender::Base;
-    mock();
+    mock_textrender();
 
 It returns the mock instance. (This is for convenience, you shouldn't
 need this (except maybe to C<unmock_all>?). C<Test::MockModule>
@@ -104,7 +104,7 @@ instance.)
 
 =cut
 
-sub mock
+sub mock_textrender
 {
     my $includepath = shift;
 

--- a/build-scripts/src/test/perl/textrender-base.t
+++ b/build-scripts/src/test/perl/textrender-base.t
@@ -3,18 +3,18 @@ use warnings;
 use Test::More;
 use Cwd;
 
-use Test::Quattor::TextRender::Base qw(mock $TARGET_TT_DIR);
+use Test::Quattor::TextRender::Base qw(mock_textrender $TARGET_TT_DIR);
 use EDG::WP4::CCM::TextRender;
 
 is($TARGET_TT_DIR, "target/share/templates/quattor",
    "Expected relative TT stage dir");
 
-my $mockinstance = mock();
+my $mockinstance = mock_textrender();
 my $trd = EDG::WP4::CCM::TextRender->new("whatever", {});
 isa_ok($trd, "EDG::WP4::CCM::TextRender", "TextRender instance");
 is($trd->{includepath},
    getcwd()."/$TARGET_TT_DIR",
-   "EDG::WP4::CCM::TextRedner with mocked CAF::TextRender has expected includepath");
+   "EDG::WP4::CCM::TextRender with mocked CAF::TextRender has expected includepath");
 
 $mockinstance->unmock_all();
 $trd = EDG::WP4::CCM::TextRender->new("whatever", {});


### PR DESCRIPTION
Unittest will fail, but fix should be as simple as changing
```perl
use Test::Quattor::TextRender::Base;
mock();
```

to 

```perl
use Test::Quattor::TextRender::Base;
mock_textrender();
```