### PR TITLE
create pod files from pm instead of separate files

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -166,8 +166,8 @@
                       <directory>src/main/perl</directory>
                       <filtering>true</filtering>
                       <includes>
-                        <include>*.pod</include>
-                        <include>**/*.pod</include>
+                        <include>*.pm</include>
+                        <include>**/*.pm</include>
                       </includes>
                     </resource>
                   </resources>

--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -186,8 +186,8 @@
                 </goals>
                 <configuration>
                   <tasks name="Rename">
-                    <move filtering="true" todir="${project.build.directory}/doc/pod/CAF">
-                      <fileset dir="${project.build.directory}/doc/pod/CAF" />
+                    <move filtering="true" todir="${project.build.directory}/doc/pod/NCM/Component">
+                      <fileset dir="${project.build.directory}/doc/pod/NCM/Component" />
                       <mapper>
                         <globmapper from="*.pm" to="*.pod" />
                       </mapper>

--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -176,6 +176,29 @@
             </executions>
           </plugin>
           <plugin>
+            <artifactId>maven-antrun-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>rename-pod-sources</id>
+                <phase>process-sources</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <tasks name="Rename">
+                    <move filtering="true" todir="${project.build.directory}/doc/pod/CAF">
+                      <fileset dir="${project.build.directory}/doc/pod/CAF" />
+                      <mapper>
+                        <globmapper from="*.pm" to="*.pod" />
+                      </mapper>
+                    </move>
+                    <echo>Renaming pm to pod</echo>
+                  </tasks>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
             <groupId>org.quattor.pan</groupId>
             <artifactId>panc-maven-plugin</artifactId>
             <version>10.2</version>

--- a/build-scripts/src/main/perl/pod2man.pl
+++ b/build-scripts/src/main/perl/pod2man.pl
@@ -52,7 +52,6 @@ sub extract_module_name {
 sub extract_pod_name {
     my ($name) = @_;
 
-    $name =~ s!\.pm!\.pod!gx;
     $name =~ s!/lib/perl/!/doc/pod/!x;
 
     return $name;

--- a/build-scripts/src/main/perl/pod2man.pl
+++ b/build-scripts/src/main/perl/pod2man.pl
@@ -52,6 +52,7 @@ sub extract_module_name {
 sub extract_pod_name {
     my ($name) = @_;
 
+    $name =~ s!\.pm!\.pod!gx;
     $name =~ s!/lib/perl/!/doc/pod/!x;
 
     return $name;


### PR DESCRIPTION
On last workshop it was decided to keep the documentation with the code. This change copies the pm files and renames them to pod. These are then used for man and markdown.

The renaming is required or pod2man.pl fails. This is similar to what we already do in CAF.