### PR TITLE
Update maven plugins used by build tools

### DIFF
--- a/BUILD_INFO.md
+++ b/BUILD_INFO.md
@@ -108,6 +108,28 @@ must be updated manually in the pom file if a new version exists and you want to
 *Note: it is important to define the version to use for dependencies and plugins present in the configuration. Maven raises a
 warning if this is not the case. When this is not done in the parent pom, if any defined, it has to be done in the child pom.*
 
+Updating the Maven plugins used
+-------------------------------
+
+To build the build tools and the various Quattor components, we rely on many Maven plugins whose version is fixed in 
+the main pom.xml file (the one in the top directory of the build tools). This is to ensure than when an old release is
+rebuilt, this is done with the same version of the Maven plugins as the one originally used.
+
+It remains important to update regurlarly the version used for every plugin. To help identifying the most recent of
+a plugin compatible with the Maven version used, use the following command (for the build tools, use the same 
+Maven options as those used for building them, see above):
+
+```
+mvn versions:display-plugin-updates
+```
+
+Based on the information displayed, update the main pom.xml files (look for the `plugins` section). Normally,
+there is no reason to define the plugin version in the pom.xml file of a particular Quattor component. Nevertheless
+it is always good to check if you suspect something is not working as expected.
+
+Normally, this is enough to run this command for the build tools as all plugins should be declared here. But this is
+possible to run it for any Quattor component: this may help to diagnose problems with specific components explicitly 
+defining the version of a plugin.
 
 Producing a new release of the build tools
 ------------------------------------------

--- a/pom.xml
+++ b/pom.xml
@@ -141,7 +141,7 @@
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-plugin-plugin</artifactId>
-	  <version>3.4</version>
+	  <version>2.6</version>
 	</plugin>
 
 	<plugin>
@@ -199,7 +199,7 @@
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-resources-plugin</artifactId>
-	  <version>2.7</version>
+	  <version>2.4.3</version>
 	</plugin>
 
 	<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,14 @@
 	  <version>2.1.4</version>
 	</plugin>
 
+	<plugin>
+	  <groupId>org.apache.maven.plugins</groupId>
+	  <artifactId>maven-antrun-plugin</artifactId>
+	  <version>1.8</version>
+	</plugin>
+
       </plugins>
+
     </pluginManagement>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,10 @@
     <version>7</version>
   </parent>
 
+  <prerequisites>
+    <maven>3.0.0</maven>
+  </prerequisites>
+
   <modules>
     <module>assemblies</module>
     <module>build-profile</module>

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.1</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -135,31 +135,31 @@
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-assembly-plugin</artifactId>
-	  <version>2.2</version>
+	  <version>2.5.5</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-plugin-plugin</artifactId>
-	  <version>2.6</version>
+	  <version>3.4</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-jar-plugin</artifactId>
-	  <version>2.3.1</version>
+	  <version>2.5</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-surefire-plugin</artifactId>
-	  <version>2.6</version>
+	  <version>2.18.1</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-compiler-plugin</artifactId>
-	  <version>2.3.2</version>
+	  <version>3.2</version>
 	  <configuration>
 	    <target>1.5</target>
 	    <source>1.5</source>
@@ -169,43 +169,43 @@
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-clean-plugin</artifactId>
-	  <version>2.4.1</version>
+	  <version>2.6.1</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-deploy-plugin</artifactId>
-	  <version>2.5</version>
+	  <version>2.8.2</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-install-plugin</artifactId>
-	  <version>2.3.1</version>
+	  <version>2.5.2</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-site-plugin</artifactId>
-	  <version>2.0-beta-7</version>
+	  <version>3.4</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-dependency-plugin</artifactId>
-	  <version>2.1</version>
+	  <version>2.10</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.apache.maven.plugins</groupId>
 	  <artifactId>maven-resources-plugin</artifactId>
-	  <version>2.4.3</version>
+	  <version>2.7</version>
 	</plugin>
 
 	<plugin>
 	  <groupId>org.codehaus.mojo</groupId>
 	  <artifactId>exec-maven-plugin</artifactId>
-	  <version>1.2</version>
+	  <version>1.4.0</version>
 	</plugin>
 
 	<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
 	<plugin>
 	  <groupId>org.codehaus.mojo</groupId>
 	  <artifactId>rpm-maven-plugin</artifactId>
-	  <version>2.1-alpha-1</version>
+	  <version>2.1.4</version>
 	</plugin>
 
 	<plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -214,12 +214,6 @@
 	  <version>2.1.4</version>
 	</plugin>
 
-	<plugin>
-          <groupId>org.quattor.maven</groupId>
-          <artifactId>maven-quattor-build-plugin</artifactId>
-	  <version>1.11-SNAPSHOT</version>
-	</plugin>
-
       </plugins>
     </pluginManagement>
   </build>


### PR DESCRIPTION
We are using old versions of all the maven plugins. Next release could be a good time to upgrade to the last ones when possible. Initial contents of this PR upgrades everything except 2 plugins that were not backward compatible...

Still work in progress.... Also some cleanup in various component pom files could be needed to have the version for every plugin only defined in the main pom file of the build tools.