### PR TITLE
TextRender support distinguished CCM cache_root for Suite runs

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
@@ -29,7 +29,7 @@ use EDG::WP4::CCM::CCfg;
 
 use Readonly;
 
-Readonly::Hash my %DEFAULT_PROFILE_CACHE_DIRS => {
+Readonly::Hash our %DEFAULT_PROFILE_CACHE_DIRS => {
     resources => "src/test/resources",
     profiles => "target/test/profiles",
     cache => "target/test/cache",
@@ -45,11 +45,11 @@ retrieve_retries 1
 EOF
 
 our @EXPORT = qw(get_config_for_profile prepare_profile_cache
-                 set_profile_cache_options
+                 set_profile_cache_options get_profile_cache_dirs
                  prepare_profile_cache_panc_includedirs
                  set_json_typed get_json_typed
                 );
-
+our @EXPORT_OK = qw(%DEFAULT_PROFILE_CACHE_DIRS);
 
 # A Test::Quattor::Object instance, can be used as logger.
 my $object = Test::Quattor::Object->new();

--- a/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
@@ -35,11 +35,11 @@ Readonly::Hash my %DEFAULT_PROFILE_CACHE_DIRS => {
     cache => "target/test/cache",
 };
 
-Readonly my $CCM_CONFIG_DEFAULT_DATA => <<"EOF";
+Readonly my $CCM_CONFIG_DEFAULT_TEMPLATE => <<"EOF";
 debug 0
 get_timeout 1
 profile http://www.quattor.org
-cache_root $DEFAULT_PROFILE_CACHE_DIRS{cache}
+cache_root __CACHE_ROOT__
 retrieve_wait 0
 retrieve_retries 1
 EOF
@@ -125,6 +125,17 @@ sub get_profile_cache_dirs
     }
 
     return \%dirs;
+}
+
+# get default ccm.cfg contents
+sub get_ccm_config_default
+{
+    my $txt = "$CCM_CONFIG_DEFAULT_TEMPLATE";
+
+    my $dirs = get_profile_cache_dirs();
+    $txt =~ s/__CACHE_ROOT__/$dirs->{cache}/g;
+
+    return $txt;
 }
 
 # convert e.g. absolute paths to usable name
@@ -221,7 +232,7 @@ sub prepare_profile_cache
         $ccmconfig = "$dirs->{cache}/ccm.cfg";
         if (! -f $ccmconfig) {
             my $fh = CAF::FileWriter->new($ccmconfig);
-            print $fh $CCM_CONFIG_DEFAULT_DATA;
+            print $fh get_ccm_config_default();
             $fh->close();
         }
     }

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
@@ -11,6 +11,9 @@ package Test::Quattor::TextRender::Base;
 use Test::More;
 use Test::MockModule;
 use Test::Quattor::Panc qw(set_panc_includepath);
+use Test::Quattor::ProfileCache qw(set_profile_cache_options
+    get_profile_cache_dirs %DEFAULT_PROFILE_CACHE_DIRS
+);
 
 use Test::Quattor::TextRender::Suite;
 
@@ -64,6 +67,12 @@ sub test
     my $testspath = $self->{testspath};
     $testspath .= "/$self->{version}" if (exists($self->{version}));
 
+    my $orig_dirs = get_profile_cache_dirs();
+    my $cachedir = "$DEFAULT_PROFILE_CACHE_DIRS{cache}/$self->{pannamespace}";
+    $cachedir .= "/$self->{version}" if (exists($self->{version}));
+
+    set_profile_cache_options(cache => $cachedir);
+
     my $base = getcwd() . "/src/test/resources";
     my $st   = Test::Quattor::TextRender::Suite->new(
         ttrelpath => $self->{ttrelpath},
@@ -73,6 +82,8 @@ sub test
 
     $st->test();
 
+    # TODO: reset it?
+    #set_profile_cache_options(cache => $orig_dirs->{cache});
 }
 
 

--- a/build-scripts/src/test/perl/profilecache.t
+++ b/build-scripts/src/test/perl/profilecache.t
@@ -36,6 +36,21 @@ my $tmp_tlc_dir = tempdir(DIR => $target);
 
 $ENV{QUATTOR_TEST_TEMPLATE_LIBRARY_CORE} = $tmp_tlc_dir;
 
+# Test default ccm.cfg
+my $ccm_default = <<"EOF";
+debug 0
+get_timeout 1
+profile http://www.quattor.org
+cache_root $target/test/cache
+retrieve_wait 0
+retrieve_retries 1
+EOF
+
+my $ccmcfg = Test::Quattor::ProfileCache::get_ccm_config_default();
+is($ccmcfg, $ccm_default,
+   "get_ccm_config_default returned expected config with default value for cache_root");
+
+
 my $cfg = prepare_profile_cache('profilecache');
 
 isa_ok($cfg, "EDG::WP4::CCM::Configuration",
@@ -76,10 +91,20 @@ is_deeply($dirs, {
     cache => "$currentdir/target/test/cache",
     }, "Default profile_cache directories");
 
-set_profile_cache_options(resources => 'src/test/resources/myresources');
+set_profile_cache_options(
+    resources => 'src/test/resources/myresources',
+    cache => 'target/test/cache/mycache',
+);
 $dirs = Test::Quattor::ProfileCache::get_profile_cache_dirs();
 is($dirs->{resources}, "$currentdir/src/test/resources/myresources",
     "Set and retrieved custom profile_cache resources dir");
+is($dirs->{cache}, "$currentdir/target/test/cache/mycache",
+    "Set and retrieved custom profile_cache cache dir");
+
+$ccmcfg = Test::Quattor::ProfileCache::get_ccm_config_default();
+like($ccmcfg, qr{^cache_root .*/cache/mycache$}m,
+   "get_ccm_config_default returned expected config with custom cache_root");
+
 
 # test rename
 is(Test::Quattor::ProfileCache::profile_cache_name("test"), "test",

--- a/build-scripts/src/test/perl/profilecache.t
+++ b/build-scripts/src/test/perl/profilecache.t
@@ -9,13 +9,21 @@ use EDG::WP4::CCM::Element qw(escape);
 
 use Test::Quattor::ProfileCache qw(prepare_profile_cache
     get_config_for_profile set_profile_cache_options
-    set_json_typed get_json_typed);
+    get_profile_cache_dirs set_json_typed get_json_typed 
+    %DEFAULT_PROFILE_CACHE_DIRS);
 use Test::Quattor::Object qw($TARGET_PAN_RELPATH);
 use Test::Quattor::Panc qw(get_panc_includepath);
 use Cwd qw(getcwd);
 use File::Temp qw(tempdir);
 use File::Path qw(mkpath);
 
+is_deeply(\%DEFAULT_PROFILE_CACHE_DIRS,
+          {
+              resources => "src/test/resources",
+              profiles => "target/test/profiles",
+              cache => "target/test/cache",
+          }, "Expected DEFAULT_PROFILE_CACHE_DIRS");
+          
 # Can't have NoAction here, since no CAF mocking happens
 # and otherwise nothing would be written
 
@@ -84,7 +92,7 @@ is_deeply($cfg, $cfg2,
 
 # verify defaults; they shouldn't "just" change
 my $currentdir = getcwd();
-my $dirs = Test::Quattor::ProfileCache::get_profile_cache_dirs();
+my $dirs = get_profile_cache_dirs();
 is_deeply($dirs, {
     resources => "$currentdir/src/test/resources",
     profiles => "$currentdir/target/test/profiles",
@@ -95,7 +103,7 @@ set_profile_cache_options(
     resources => 'src/test/resources/myresources',
     cache => 'target/test/cache/mycache',
 );
-$dirs = Test::Quattor::ProfileCache::get_profile_cache_dirs();
+$dirs = get_profile_cache_dirs();
 is($dirs->{resources}, "$currentdir/src/test/resources/myresources",
     "Set and retrieved custom profile_cache resources dir");
 is($dirs->{cache}, "$currentdir/target/test/cache/mycache",
@@ -103,14 +111,14 @@ is($dirs->{cache}, "$currentdir/target/test/cache/mycache",
 
 $ccmcfg = Test::Quattor::ProfileCache::get_ccm_config_default();
 like($ccmcfg, qr{^cache_root .*/cache/mycache$}m,
-   "get_ccm_config_default returned expected config with custom cache_root");
+     "get_ccm_config_default returned expected config with custom cache_root");
 
 
 # test rename
 is(Test::Quattor::ProfileCache::profile_cache_name("test"), "test",
-    "Profilecache name preserves original behaviour");
+   "Profilecache name preserves original behaviour");
 is(Test::Quattor::ProfileCache::profile_cache_name("$dirs->{resources}/subtree/test.pan"), escape("subtree/test"),
-    "Profilecache name handles absolute paths");
+   "Profilecache name handles absolute paths");
 
 
 # test absolute path

--- a/build-scripts/src/test/perl/textrender-component.t
+++ b/build-scripts/src/test/perl/textrender-component.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Quattor::ProfileCache;
 use Test::Quattor::TextRender::Component;
 use Cwd qw(getcwd);
 
@@ -40,6 +41,11 @@ isa_ok($st, "Test::Quattor::TextRender::Component",
        "Returns Test::Quattor::TextRender::Component instance for service");
 # the actual method to test
 $st->test();
+
+my $dirs = get_profile_cache_dirs();
+like($dirs->{cache},
+     qr{/target/test/cache/components/mycomp$},
+     "cache root set to pannamespace");
 
 # Test the skippan on a directory that has no pan files
 # tests would fail if skippan isn't set to true

--- a/build-scripts/src/test/perl/textrender-metaconfig.t
+++ b/build-scripts/src/test/perl/textrender-metaconfig.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 
 use Test::More;
+use Test::Quattor::ProfileCache;
 use Test::Quattor::TextRender::Metaconfig;
 use Cwd;
 
@@ -9,7 +10,7 @@ use Cwd;
 
 =head1 DESCRIPTION
 
-Test the metaconfig unittest. This is NOT an example to use 
+Test the metaconfig unittest. This is NOT an example to use
 the Test::Quattor::TextRender::Metaconfig test().
 
 =cut
@@ -21,22 +22,27 @@ my $st = Test::Quattor::TextRender::Metaconfig->new(
     basepath => getcwd()."/src/test/resources/metaconfig",
     );
 
-isa_ok($st, "Test::Quattor::TextRender::Metaconfig", 
+isa_ok($st, "Test::Quattor::TextRender::Metaconfig",
        "Returns Test::Quattor::TextRender::Metaconfig instance for service");
 
 # don't do this in real tests unless you have a very good reason.
 $st->{expect}->{invalidtt} = [
     'testservice/1.0/failed_syntax.tt',
-    'testservice/1.0/tests/profiles/notarealtt.tt', 
+    'testservice/1.0/tests/profiles/notarealtt.tt',
     'testservice/pan/notarealtt.tt',
     ];
 $st->{expect}->{invalidpan} = [
-    'testservice/pan/invalid_name.pan', 
-    'testservice/pan/invalid_namespace.pan', 
+    'testservice/pan/invalid_name.pan',
+    'testservice/pan/invalid_namespace.pan',
     'testservice/pan/invalid_type.pan',
     ];
 
 # the actual method to test
 $st->test();
+
+my $dirs = get_profile_cache_dirs();
+like($dirs->{cache},
+     qr{/target/test/cache/metaconfig/testservice/1.0$},
+     "cache root set to verisoned pannamespace");
 
 done_testing();


### PR DESCRIPTION
E.g. in metaconfig, 2 services with same test profiles will have problems as the test framework doesn't handle this properly