### PR TITLE
Make the RPMs more rpmlint compliant.

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -364,28 +364,23 @@ ${line.separator}
           <artifactId>rpm-maven-plugin</artifactId>
           <configuration>
             <release>${RELEASE}</release>
-            <summary>ncm-${project.artifactId}</summary>
+            <summary>NCM component for ${project.artifactId}</summary>
             <name>ncm-${project.artifactId}</name>
             <group>Quattor</group>
             <packager>Quattor</packager>
             <vendor>Quattor</vendor>
+            <defaultDirmode>755</defaultDirmode>
+            <defaultFilemode>644</defaultFilemode>
+            <defaultUsername>root</defaultUsername>
+            <defaultGroupname>root</defaultGroupname>
+            <license>ASL 2.0 and EU Datagrid</license>
             <copyright>${license-url}</copyright>
-            <url>${project.url}</url>
-            <provides>
-              <provide>ncm-${project.artifactId}</provide>
-            </provides>
+            <url>https://github.com/quattor/configuration-modules-core/tree/master/ncm-${project.artifactId}</url>
             <needarch>noarch</needarch>
             <description>${project.name}</description>
-            <requires>
-              <require>ncm-ncd</require>
-              <require>libuser</require>
-            </requires>
             <mappings>
               <mapping>
                 <directory>/usr/lib</directory>
-                <filemode>755</filemode>
-                <username>root</username>
-                <groupname>root</groupname>
                 <directoryIncluded>false</directoryIncluded>
                 <sources>
                   <source>
@@ -411,9 +406,6 @@ ${line.separator}
               </mapping>
               <mapping>
                 <directory>/usr/share/doc/pan</directory>
-                <filemode>644</filemode>
-                <username>root</username>
-                <groupname>root</groupname>
                 <documentation>true</documentation>
                 <directoryIncluded>false</directoryIncluded>
                 <sources>
@@ -424,9 +416,6 @@ ${line.separator}
               </mapping>
               <mapping>
                 <directory>${man.page.dir}</directory>
-                <filemode>644</filemode>
-                <username>root</username>
-                <groupname>root</groupname>
                 <documentation>true</documentation>
                 <directoryIncluded>false</directoryIncluded>
                 <sources>


### PR DESCRIPTION
We have started running our RPM packages through rpmlint, and it flagged up a few issues with the RPMs produced by maven for NCM components.

I guess some discussion will be needed about which ones we actually care about, and how/if to fix them, but I've made a few changes to the build-profile pom.xml which addresses some of them.

Do we even need the libuser dependency? Maybe some RPM needs it, but I doubt it should be a dependency of every RPM built. In any case, RPM packaging guidelines say autodetecting libraries is preferred to explicitly putting them in.

Before:

ncm-ccm.noarch: E: explicit-lib-dependency libuser
ncm-ccm.noarch: W: summary-not-capitalized C ncm-ccm
ncm-ccm.noarch: W: name-repeated-in-summary C ncm-ccm
ncm-ccm.noarch: W: non-standard-group Quattor
ncm-ccm.noarch: E: no-changelogname-tag
ncm-ccm.noarch: W: invalid-license c
ncm-ccm.noarch: W: invalid-license Quattor
ncm-ccm.noarch: W: invalid-url URL: http://quattor.org/cfg-modules/ccm/ HTTP Error 404: Not Found
ncm-ccm.noarch: E: useless-provides ncm-ccm
ncm-ccm.noarch: E: script-without-shebang /usr/lib/perl/NCM/Component/ccm.pm
1 packages and 0 specfiles checked; 4 errors, 6 warnings.

After:

ncm-ccm.noarch: W: non-standard-group Quattor
ncm-ccm.noarch: E: no-changelogname-tag
ncm-ccm.noarch: E: script-without-shebang /usr/lib/perl/NCM/Component/ccm.pm
1 packages and 0 specfiles checked; 2 errors, 1 warnings.

The script-without-shebang one seems bogus, obviously we don't put that in .pm files, so we'll probably just ignore it.