### PR TITLE
Test::Quattor: mocked FileWriter close handles backup

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -387,6 +387,10 @@ sub new_filewriter_close
         $ret = (! defined($current_content)) || $current_content ne $new_content;
     }
 
+    if ($ret && defined($current_content) && defined(*$self->{options}->{backup})) {
+        $desired_file_contents{*$self->{filename} . *$self->{options}->{backup}} =  $current_content;
+    }
+
     return $ret;
 }
 

--- a/build-scripts/src/test/perl/quattor_mock.t
+++ b/build-scripts/src/test/perl/quattor_mock.t
@@ -50,6 +50,11 @@ print $fh5 $DATA x 2;
 $changed = $fh5->close();
 ok($changed, "Same file, new data, NoAction and caf_file_close_diff set");
 
+my $fh6 = CAF::FileWriter->new($fn2, backup => '.old');
+print $fh6 $DATA x 3;
+$changed = $fh6->close();
+ok($changed, "Same file, new data, backup, NoAction and caf_file_close_diff set");
+
 #
 # Read what has been written
 #
@@ -58,6 +63,13 @@ $fh = CAF::FileReader->new($fn);
 is("$fh", $DATA, "Reader reads what Writer has written");
 $fh->close;
 
+$fh = CAF::FileReader->new("$fn2");
+is("$fh", $DATA x 3, "Reader reads what Writer fh6 has written");
+$fh->close;
+
+$fh = CAF::FileReader->new("$fn2.old");
+# backup is fh5
+is("$fh", $DATA x 2, "Reader reads what Writer fh6 has written as backup");
+$fh->close;
 
 done_testing;
-


### PR DESCRIPTION
Using backup in `CAF::File*` tools will also generate a mocked backup file.