### PR TITLE
Perl warnings during tests are equivalent to failing test (and warn_is_ok function to disable this behaviour)

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -203,12 +203,15 @@ Defaults to false (to keep regular C<NoAction> behaviour).
 
 my $caf_file_close_diff = 0;
 
+# By default, perl warnings are not ok
+my $_warn_is_ok = 0;
 
 our @EXPORT = qw(get_command set_file_contents get_file set_desired_output
                  set_desired_err get_config_for_profile set_command_status
                  command_history_reset command_history_ok set_service_variant
                  set_caf_file_close_diff
-                 make_directory remove_any reset_caf_path);
+                 make_directory remove_any reset_caf_path
+                 warn_is_ok);
 
 my @logopts = qw(--verbose);
 my $debuglevel = $ENV{QUATTOR_TEST_LOG_DEBUGLEVEL};
@@ -241,6 +244,15 @@ sub import
 
     $class->SUPER::export_to_level(1, $class, @EXPORT);
 }
+
+$SIG{__WARN__} = sub {
+    my $msg = "Perl warning: $_[0]";
+    if ($_warn_is_ok) {
+        diag $msg;
+    } else {
+        ok(0, $msg);
+    }
+};
 
 =pod
 
@@ -1074,6 +1086,22 @@ sub reset_caf_path
 
 }
 
+=item warn_is_ok
+
+By default, Perl warnings are mapped to failing tests.
+
+
+
+=cut
+
+sub warn_is_ok
+{
+    my ($bool) = @_;
+
+    $bool = 1 if ! defined($bool);
+
+    $_warn_is_ok = $bool ? 1 : 0;
+}
 
 1;
 

--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -926,8 +926,10 @@ sub is_file
 {
     my $path = sane_path(shift);
 
-    my $f_c = exists($files_contents{$path}) && "$files_contents{$path}" ne $DIRECTORY;
-    my $d_f_c  = exists($desired_file_contents{$path}) && "$desired_file_contents{$path}" ne $DIRECTORY;
+    my $f_c = exists($files_contents{$path}) &&
+        (! defined($files_contents{$path}) || "$files_contents{$path}" ne $DIRECTORY);
+    my $d_f_c  = exists($desired_file_contents{$path}) &&
+        (! defined($desired_file_contents{$path}) || "$desired_file_contents{$path}" ne $DIRECTORY);
 
     return $f_c || $d_f_c;
 }
@@ -942,8 +944,10 @@ sub is_directory
 {
     my $path = sane_path(shift);
 
-    my $f_c = exists($files_contents{$path}) && "$files_contents{$path}" eq $DIRECTORY;
-    my $d_f_c  = exists($desired_file_contents{$path}) && "$desired_file_contents{$path}" eq $DIRECTORY;
+    my $f_c = exists($files_contents{$path}) &&
+        $files_contents{$path} && "$files_contents{$path}" eq $DIRECTORY;
+    my $d_f_c  = exists($desired_file_contents{$path}) &&
+        $desired_file_contents{$path} && "$desired_file_contents{$path}" eq $DIRECTORY;
 
     return $f_c || $d_f_c;
 }

--- a/build-scripts/src/test/perl/quattor.t
+++ b/build-scripts/src/test/perl/quattor.t
@@ -5,7 +5,7 @@ use Test::More;
 
 # Test the import method
 use Test::Quattor qw(quattor);
-
+use Test::MockModule;
 use CAF::Service;
 
 use CAF::Object;
@@ -13,15 +13,58 @@ $CAF::Object::NoAction = 1;
 
 my $cfg = get_config_for_profile('quattor');
 
-isa_ok($cfg, "EDG::WP4::CCM::Configuration", 
+isa_ok($cfg, "EDG::WP4::CCM::Configuration",
             "get_config_for_profile returns a EDG::WP4::CCM::Configuration instance");
 
-is_deeply($cfg->getElement("/")->getTree(), 
-            {test => "data"}, 
+is_deeply($cfg->getElement("/")->getTree(),
+            {test => "data"},
             "getTree of root element returns correct hashref");
 
 is(CAF::Service::os_flavour(), 'linux_sysv', 'Test::Quattor sets linux_sysv by default');
 set_service_variant('linux_systemd');
 is(CAF::Service::os_flavour(), 'linux_systemd', 'linux_systemd set as variant');
+
+# Test warn_is_ok
+
+# Mock the ok call
+# This is the default
+my $ok;
+
+my $mocked_ok = sub {
+    my($self, $test, $name) = @_;
+    diag("Test ok mocked: ".(defined($test) ? $test : "<undef>"). " $name");
+    $ok = "$test $name";
+};
+
+my $mock = Test::MockModule->new('Test::Builder');
+$mock->mock('ok', $mocked_ok);
+
+warn "a perl warning default";
+
+# unmock the mocked test class
+$mock->unmock_all();
+
+like($ok, qr{0 Perl warning: a perl warning default at },
+     "warn triggers a failing test by default");
+
+# warnings are ok
+warn_is_ok();
+warn "a perl warning undef (this is a test of a warning; please ignore)";
+warn_is_ok(1);
+warn "a perl warning 1 (this is a test of a warning; please ignore)";
+
+# warnings are not ok
+warn_is_ok(0);
+
+$mock->mock('ok', $mocked_ok);
+
+warn "a perl warning 0";
+
+# unmock the mocked test class
+$mock->unmock_all();
+
+like($ok, qr{0 Perl warning: a perl warning 0 at },
+     "warn triggers a failing test with warn_is_ok(0)");
+
 
 done_testing();


### PR DESCRIPTION
Treat perl warnings as equivalent to the failure of a test.

Can be disabled by calling `warn_is_ok()` and reenabled by `warn_is_ok(0)`