### PR TITLE
Test::Quattor::Unittest: add baseline unittests

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor/Doc.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Doc.pm
@@ -131,10 +131,10 @@ sub pod_files
 
 =item pan_annotations
 
-Generate annotations, return arrayref with templates that 
+Generate annotations, return arrayref with templates that
 have valid annotations and one for templates with invalid annotations.
 
-TODO: Does not require annotations at all nor validates 
+TODO: Does not require annotations at all nor validates
 minimal contents.
 
 =cut
@@ -189,8 +189,10 @@ sub test
     my ($ok, $not_ok) = $self->pod_files();
     is(scalar @$not_ok, 0, "No faulty pod files: ");
 
-    ($ok, $not_ok) = $self->pan_annotations();
-    is(scalar @$not_ok, 0, "No faulty pan annotation: ".join(",", @$not_ok));
+    if (defined($self->{panpaths})) {
+        ($ok, $not_ok) = $self->pan_annotations();
+        is(scalar @$not_ok, 0, "No faulty pan annotation: ".join(",", @$not_ok));
+    }
 }
 
 =pod

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Base.pm
@@ -73,7 +73,6 @@ sub test
 
     set_profile_cache_options(cache => $cachedir);
 
-    my $base = getcwd() . "/src/test/resources";
     my $st   = Test::Quattor::TextRender::Suite->new(
         ttrelpath => $self->{ttrelpath},
         ttincludepath => $self->{ttincludepath},

--- a/build-scripts/src/main/perl/Test/Quattor/TextRender/Component.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/TextRender/Component.pm
@@ -83,23 +83,27 @@ Default is not to skip any pan related tests.
 
 =cut
 
+# return default basepath
+sub _default_basepath
+{
+    my $srcpath = getcwd() . "/src/main";
+    return "$srcpath/resources";
+}
+
 sub _initialize
 {
     my ($self) = @_;
 
-    ok($self->{component}, "Component name set " . ($self->{component} || ""));
+    ok($self->{component}, "Component name set " . ($self->{component} || "<undef>"));
 
     if (!defined($self->{usett})) {
         $self->{usett} = 1;
     }
     $self->verbose("usett $self->{usett}");
 
-    my $srcpath    = getcwd() . "/src/main";
     my $targetpath = getcwd() . "/target";
 
-    if (!$self->{basepath}) {
-        $self->{basepath} = "$srcpath/resources";
-    }
+    $self->{basepath} = _default_basepath() if (!$self->{basepath});
 
     # TT files are unfolded in the targetpath wrt the expected relpath
     # by the pom.xml (tt file under src/main/resources/data.tt for component

--- a/build-scripts/src/main/perl/Test/Quattor/Unittest.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Unittest.pm
@@ -20,18 +20,20 @@ END {
     done_testing() if $do_test;
 }
 
+use Test::Quattor::Doc;
+
 # When changing, also change the pod in read_cfg
 Readonly our $CFG_FILENAME => 'tqu.cfg';
 Readonly our $DEFAULT_CFG => <<'EOF';
 [load]
 enable = 1
 
-[pod]
+[doc]
 enable = 1
 
 EOF
 
-Readonly::Array our @TESTS => qw(load);
+Readonly::Array our @TESTS => qw(load doc);
 
 =pod
 
@@ -234,6 +236,36 @@ sub load
     }
 }
 
+
+=item doc
+
+Documentation tests using C<Test::Quattor::Doc>.
+
+Configuration options C<poddirs>, C<podfiles>, C<panpaths> and
+C<panout> are prased as comma-sperated lists
+and passed to C<Test::Quattor::Doc->new>.
+
+C<panpaths> value C<NOPAN> is special, as it disables the pan tests.
+
+=cut
+
+sub doc
+{
+    my ($self, $cfg) = @_;
+
+    my %opts;
+    foreach my $opt (qw(poddirs podfiles panpaths panout)) {
+        $opts{$opt} = [split(/\s*,\s*/, $cfg->{$opt})] if exists $cfg->{$opt};
+    }
+
+    my $doc = Test::Quattor::Doc->new(%opts);
+    if(($cfg->{panpaths} || '') eq 'NOPAN') {
+        $self->verbose('disabling pan doc tests');
+        $doc->{panpaths} = undef;
+    }
+
+    $doc->test();
+}
 
 =pod
 

--- a/build-scripts/src/main/perl/Test/Quattor/Unittest.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Unittest.pm
@@ -1,0 +1,244 @@
+# ${license-info}
+# ${developer-info}
+# ${author-info}
+# ${build-info}
+
+use strict;
+use warnings;
+
+package Test::Quattor::Unittest;
+
+use parent qw(Test::Quattor::Object);
+use Config::Tiny;
+use Readonly;
+use Test::More;
+
+my $do_test = 1;
+# This is the very last thing to do
+# Defined here to always run as last, even after the END from e.g. NoWarnings
+END {
+    done_testing() if $do_test;
+}
+
+# When changing, also change the pod in read_cfg
+Readonly our $CFG_FILENAME => 'tqu.cfg';
+Readonly our $DEFAULT_CFG => <<'EOF';
+[load]
+enable = 1
+
+[pod]
+enable = 1
+
+EOF
+
+Readonly::Array our @TESTS => qw(load);
+
+=pod
+
+=head1 NAME
+
+Test::Quattor::Unittest - Baseline unittest module.
+
+=head1 DESCRIPTION
+
+This is a class to trigger basic unittests.
+Should be used as follows:
+
+    use Test::Quattor::Unittest;
+
+Adding the test is as simple as
+    echo 'use Test::Quattor::Unittest;' > 00-tqu.t
+
+=head1 FUNCTIONS
+
+=over
+
+=item import
+
+On import, run the tests.
+
+Pass C<notest> to disable automatic testing
+(only useful when testing this code).
+
+=cut
+
+sub import
+{
+    my $class = shift;
+
+    $do_test = ! grep {m/notest/} @_;
+    $class->new()->test() if $do_test;
+}
+
+=pod
+
+=back
+
+=head1 METHODS
+
+=over
+
+=item new
+
+No options are required/supported
+
+=cut
+
+sub _initialize
+{
+
+}
+
+=item read_cfg
+
+Read default config followed by optional configfile C<tqu.cfg> and optional
+variable C<$main::TQU>.
+
+Variable can be defined in main test as follows
+    BEGIN {
+    our $TQU = <<'EOF';
+    ...
+    EOF
+    }
+
+Every test section has at least the C<enable> option,
+set to true by default. For all other options, read the respective method
+documentation.
+
+=cut
+
+# inplace merge of src with href of depth 2
+# no merging at depth 1
+sub _merge
+{
+    my ($src, $href) = @_;
+    while (my ($k, $v) = each %$href) {
+        $src->{$k} = {%{$src->{$k} || {}}, %$v};
+    }
+}
+
+sub read_cfg
+{
+    my $self = shift;
+
+    my $cfg = Config::Tiny->read_string($DEFAULT_CFG);
+
+    if (-f $CFG_FILENAME ) {
+        $self->info("TQU cfg file $CFG_FILENAME found");
+        _merge($cfg, $cfg->read($CFG_FILENAME));
+    } else {
+        $self->verbose("No TQU cfg file $CFG_FILENAME found");
+    }
+
+    if ($main::TQU) {
+        $self->info("main::TQU cfg string found");
+        _merge($cfg, $cfg->read_string($main::TQU));
+    } else {
+        $self->verbose("No main::TQU cfg string found");
+    };
+
+    $self->{cfg} = $cfg;
+}
+
+=item test
+
+Run all enabled tests, in order
+
+=cut
+
+sub test
+{
+
+    my ($self) = shift;
+
+    $self->read_cfg();
+
+    foreach my $test (@TESTS) {
+        my $cfg = $self->{cfg}->{$test};
+        if (! defined($cfg)) {
+            $self->notok("No configuration section for test $test");
+        } else {
+            $self->$test($cfg);
+        };
+    }
+}
+
+=item load
+
+Run basic load test using C<use_ok> from C<Test::More>.
+
+The module(s) can be configured or guessed.
+
+Configuration parameters
+
+=over
+
+=item modules
+
+Comma separated list op module names to try to load.
+
+When specified, no guesses are made, only this list is used.
+
+If C<:> is passed, the prefix is used.
+
+All trailing C<:> are removed.
+
+=item prefix
+
+A prefix for all modules specified in the C<modules> option.
+
+=back
+
+=cut
+
+# For unittesting, do not run tests
+sub _get_modules
+{
+    my ($self, $cfg) = @_;
+
+    my $prefix = $cfg->{prefix} || '';
+
+    my @split = split(/\s*,\s*/, $cfg->{modules} || '');
+
+    my @modules = map {s/:*$//;$_} map {$prefix . ($_ eq ':' ? '' : $_)} @split;
+
+    if (@modules) {
+        $self->verbose("Configured modules to load: ", join(', ', @modules));
+    } else {
+        # Is this a component?
+
+
+        if (@modules) {
+            $self->verbose("Guessed modules to load: ", join(', ', @modules));
+        } else {
+            $self->verbose("No modules configured or guessed");
+        };
+    }
+
+    return \@modules;
+}
+
+sub load
+{
+
+    my ($self, $cfg) = @_;
+
+    my $modules = $self->_get_modules($cfg);
+
+    if (@$modules) {
+        foreach my $module (@$modules) {
+            use_ok($module);
+        }
+    } else {
+        $self->notok("No modules configured or guessed");
+    }
+}
+
+
+=pod
+
+=back
+
+=cut
+
+1;

--- a/build-scripts/src/test/perl/00-tqu.t
+++ b/build-scripts/src/test/perl/00-tqu.t
@@ -1,0 +1,10 @@
+BEGIN {
+our $TQU = <<'EOF';
+[load]
+prefix=Test::Quattor::
+# Do NOT list Unittest here, it will cause an infinite loop
+# Unittest is tested elsewhere
+modules=:,CommonDeps,Component,Doc,Namespace,Object,Panc,ProfileCache,RegexpTest,TextRender,TextRender,TextRender::Base,TextRender::Component,TextRender::Metaconfig,TextRender::RegexpTest,TextRender::Suite
+EOF
+    }
+use Test::Quattor::Unittest;

--- a/build-scripts/src/test/perl/00-tqu.t
+++ b/build-scripts/src/test/perl/00-tqu.t
@@ -1,5 +1,5 @@
 BEGIN {
-our $TQU = <<'EOF';
+    our $TQU = <<'EOF';
 [load]
 prefix=Test::Quattor::
 # Do NOT list Unittest here, it will cause an infinite loop

--- a/build-scripts/src/test/perl/00-tqu.t
+++ b/build-scripts/src/test/perl/00-tqu.t
@@ -5,6 +5,9 @@ prefix=Test::Quattor::
 # Do NOT list Unittest here, it will cause an infinite loop
 # Unittest is tested elsewhere
 modules=:,CommonDeps,Component,Doc,Namespace,Object,Panc,ProfileCache,RegexpTest,TextRender,TextRender,TextRender::Base,TextRender::Component,TextRender::Metaconfig,TextRender::RegexpTest,TextRender::Suite
+[doc]
+poddirs=src/main/perl
+panpaths=NOPAN
 EOF
     }
 use Test::Quattor::Unittest;

--- a/build-scripts/src/test/perl/unittest.t
+++ b/build-scripts/src/test/perl/unittest.t
@@ -1,0 +1,41 @@
+use strict;
+use warnings;
+
+use Test::More;
+
+# No BEGIN is required, tests are not run on import
+our $TQU = <<'EOF';
+[notarealtestsection]
+a=b
+EOF
+
+# This is to test the unitest code
+use Test::Quattor::Unittest qw(notest);
+
+my $u = Test::Quattor::Unittest->new();
+isa_ok($u, 'Test::Quattor::Unittest');
+
+is_deeply(\@Test::Quattor::Unittest::TESTS, [qw(load)],
+          'ordered tests as expected');
+
+$u->read_cfg();
+is($u->{cfg}->{notarealtestsection}->{a}, 'b', 'expected value from merge main TQU');
+
+# check defaults, all tests enabled
+foreach my $test (@Test::Quattor::Unittest::TESTS) {
+    ok($u->{cfg}->{$test}->{enable}, "Default config has test $test enabled");
+    ok($u->can($test), "Test $test method found");
+}
+
+# modules
+is_deeply($u->_get_modules(), [], "No modules guessed/configured");
+
+my $cfg = {
+    prefix => 'a::b::',
+    modules => 'c,d::e,:,f'
+};
+is_deeply($u->_get_modules($cfg), [qw(a::b::c a::b::d::e a::b a::b::f)],
+          "configured modules with prefix");
+
+
+done_testing;

--- a/build-scripts/src/test/perl/unittest.t
+++ b/build-scripts/src/test/perl/unittest.t
@@ -15,7 +15,7 @@ use Test::Quattor::Unittest qw(notest);
 my $u = Test::Quattor::Unittest->new();
 isa_ok($u, 'Test::Quattor::Unittest');
 
-is_deeply(\@Test::Quattor::Unittest::TESTS, [qw(load doc)],
+is_deeply(\@Test::Quattor::Unittest::TESTS, [qw(load doc tt)],
           'ordered tests as expected');
 
 $u->read_cfg();

--- a/build-scripts/src/test/perl/unittest.t
+++ b/build-scripts/src/test/perl/unittest.t
@@ -15,7 +15,7 @@ use Test::Quattor::Unittest qw(notest);
 my $u = Test::Quattor::Unittest->new();
 isa_ok($u, 'Test::Quattor::Unittest');
 
-is_deeply(\@Test::Quattor::Unittest::TESTS, [qw(load)],
+is_deeply(\@Test::Quattor::Unittest::TESTS, [qw(load doc)],
           'ordered tests as expected');
 
 $u->read_cfg();


### PR DESCRIPTION
Introduce entry point for generic tests for all Quattor perl code.
Tests should replace existing load (aka `00-load`), pod (aka `pod-syntax`) and TT (aka `01_tt`) tests, and guide towards documentation/annotation tests via `Test::Quattor::Doc` and style tests