### PR TITLE
maven-tools: small documentation fixes

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -27,7 +27,7 @@ as C<target/test/profiles/foo.json>, while the cache will be stored in
 under C<target/test/profiles/foo/>.
 
 This binary cache may be converted in an
-L<EDG::WP4::CCM::CacheManager::Configuration> object using the
+C<EDG::WP4::CCM::CacheManager::Configuration> object using the
 C<get_config_for_profile> function.
 
 =head1 INTERNAL INFRASTRUCTURE

--- a/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
@@ -266,7 +266,7 @@ sub prepare_profile_cache
 
 Returns a configuration object for the profile given as an
 argument. The profile should be one of the arguments given to
-L<Test::Quattor> when loading it.
+C<Test::Quattor> when loading it.
 
 If the configuration cannot be found, an error is reported, and
 a test fails.


### PR DESCRIPTION
While building a new version of the documentation I found 2 small issues which will result in dead links. This fixes that.