### PR TITLE
Test::Quattor::ProfileCache: use a ccm.cfg per compiled profile

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
@@ -234,8 +234,8 @@ sub prepare_profile_cache
     my $ccmconfig = "$dirs->{resources}/ccm.cfg";
     if( ! -f $ccmconfig) {
         # Make a new default one
-        note("Creating default ccm.cfg in $dirs->{cache}");
-        $ccmconfig = "$dirs->{cache}/ccm.cfg";
+        note("Creating default ccm.cfg in $cache for profile $profile");
+        $ccmconfig = "$cache/ccm.cfg";
         if (! -f $ccmconfig) {
             my $fh = CAF::FileWriter->new($ccmconfig);
             print $fh get_ccm_config_default();


### PR DESCRIPTION
Fixes #135
There is a bug in the way the unittests mock the Writer/Reader and how it used in ProfileCache and CCM.
The main effect all but the first unittest do not use the default ccm.cfg, and in particluar, that tabcompletion is generated, which causes unnecessary slowdown.