### PR TITLE
Mocked FileWriter: set noaction=1 by default

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -360,8 +360,13 @@ sub new_filewriter_open
 {
     my $f = $old_open->(@_);
 
+    # Default in mocked FileWriter is to have 'noaction'
+    # option set to 1. Define Test::Quattor::NoAction=0
+    # to override the default.
     if(defined($NoAction)) {
         *$f->{options}->{noaction} = $NoAction;
+    } else {
+        *$f->{options}->{noaction} = 1;
     }
 
     my $fn = *$f->{filename};
@@ -432,10 +437,6 @@ sub new_fileeditor_open
 
     my ($class, $path, %opts) = @_;
     *$f->{options}->{source} = $opts{source} if exists ($opts{source});
-
-    if(defined($NoAction)) {
-        *$f->{options}->{noaction} = $NoAction;
-    }
 
     my $fn = *$f->{filename};
     if (is_directory($fn)) {

--- a/build-scripts/src/main/perl/Test/Quattor.pm
+++ b/build-scripts/src/main/perl/Test/Quattor.pm
@@ -75,6 +75,7 @@ use Test::Quattor::ProfileCache qw(prepare_profile_cache get_config_for_profile)
 use Test::Quattor::Object qw(warn_is_ok);
 use Cwd;
 use Readonly;
+use Scalar::Util qw(dualvar);
 
 # "File" content that will appear as a directory
 Readonly our $DIRECTORY => 'MAGIC STRING, THIS IS A MOCKED DIRECTORY';
@@ -691,7 +692,8 @@ $cpath->mock("directory", sub {
     } else {
         $directory = undef;
     }
-    return $directory;
+    my $status = defined($directory) ? SUCCESS : undef;
+    return dualvar ($status, $directory);
 });
 
 =item C<CAF::Path::LC_Check>

--- a/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/ProfileCache.pm
@@ -212,6 +212,10 @@ sub prepare_profile_cache
 
     mkpath($cache);
 
+    # Ensure that Test::Quattor::NoAction=0
+    my $noaction_saved = $Test::Quattor::NoAction;
+    $Test::Quattor::NoAction = 0;
+
     my $fh = CAF::FileWriter->new("$cache/global.lock");
     print $fh "no\n";
     $fh->close();
@@ -256,6 +260,9 @@ sub prepare_profile_cache
 
     my $cm =  EDG::WP4::CCM::CacheManager->new($cache);
     $configs{$cachename} = $cm->getUnlockedConfiguration();
+
+    # Restore caller $Test::Quattor::NoAction
+    $Test::Quattor::NoAction = $noaction_saved;
 
     return $configs{$cachename};
 }

--- a/build-scripts/src/test/perl/quattor_path.t
+++ b/build-scripts/src/test/perl/quattor_path.t
@@ -84,7 +84,7 @@ my $dirbase = "$BASEPATH/dirs/subdir";
 # verify dir does not exist
 ok(!$s->directory_exists($dirbase), "mocked missing dir $dirbase returns false directory_exists");
 # create dir
-is($s->make_directory($dirbase), SUCCESS, "make_directory returns success");
+is(int($s->directory($dirbase)), SUCCESS, "directory() returns success");
 ok($s->directory_exists($dirbase), "mocked dir $dirbase returns true directory_exists");
 
 # check caf_path hashref
@@ -100,7 +100,7 @@ is_deeply($Test::Quattor::caf_path, {},
           "reset_caf_path resets all if no named item is passed");
 
 # recreate dir return EXISTS
-is($s->make_directory($dirbase), $simple_caf::EXISTS, "make_directory returns EXISTS 2nd time");
+is(make_directory($dirbase), SUCCESS, "make_directory returns SUCCESS if directory exists");
 
 # test recursive paths
 my $tmppath = '';
@@ -135,7 +135,7 @@ my $dirtest = "$targetbase/dirtest";
 is($s->make_file($target1, "Link tests: target1"), SUCCESS, "make_file returns success for $target1");
 is($s->make_file($target2, "Link tests: target2"), SUCCESS, "make_file returns success for $target2");
 is($s->make_file($target3, "Link tests: target3"), SUCCESS, "make_file returns success for $target3");
-is($s->make_directory($dirtest, "Link tests: dirtest"), SUCCESS, "make_directory returns success for $dirtest");
+is(make_directory($dirtest, "Link tests: dirtest"), SUCCESS, "make_directory returns success for $dirtest");
 
 is($s->symlink($target1, $symlink1), CHANGED, "Symlink $symlink1 successfully created");
 ok($s->is_symlink($symlink1), "$symlink1 is a symlink");

--- a/build-scripts/src/test/perl/simple_caf.pm
+++ b/build-scripts/src/test/perl/simple_caf.pm
@@ -35,18 +35,5 @@ sub make_file
     }
 }
 
-# make a directory
-# if directory already exists, return $EXISTS
-sub make_directory
-{
-    my ($self, $dir) = @_;
-    if ($self->directory_exists($dir)) {
-        return $EXISTS;
-    } else {
-        $self->directory($dir);
-        return SUCCESS;
-    }
-}
-
 
 1;


### PR DESCRIPTION
Also:
- Remove `make_directory()` from simple_caf module as it is part of Test/Quattor.pm with a different interface
- Update `directory()` from `Test/Quattor.pm` to return a dualvar
  as the standard `CAF::Path::directory()`
- Update unit tests accordingly

Fixes #139.