### PR TITLE
Test::Quattor: support immutable paths that trigger CAF::Path and CAF::FileWriter related failures

### DIFF
--- a/build-scripts/src/test/perl/simple_caf.pm
+++ b/build-scripts/src/test/perl/simple_caf.pm
@@ -28,7 +28,7 @@ sub make_file
     if ($self->file_exists($filename)) {
         return $EXISTS;
     } else {
-        my $fh = CAF::FileWriter->new($filename);
+        my $fh = CAF::FileWriter->new($filename, log => $self);
         print $fh $text;
         $fh->close();
         return SUCCESS;


### PR DESCRIPTION
Fixes #164