### PR TITLE
Remove extension from templated inclusion of site-config

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -68,7 +68,7 @@ bind '/software/components/${project.artifactId}' = ${project.artifactId}_compon
 
 '/software/packages' = pkg_repl('ncm-${project.artifactId}', '${no-snapshot-version}-${rpm.release}', 'noarch');
 
-include if_exists('components/${project.artifactId}/site-config.pan');
+include if_exists('components/${project.artifactId}/site-config');
 
 prefix '/software/components/${project.artifactId}';
 'active' ?= true;

--- a/build-scripts/src/main/perl/mvnprove.pl
+++ b/build-scripts/src/main/perl/mvnprove.pl
@@ -267,7 +267,7 @@ bind '/software/components/$project' = ${project}_component;
 
 '/software/packages' = pkg_repl('ncm-$project', '$version-$snapshot', 'noarch');
 
-include if_exists('components/$project/site-config.pan');
+include if_exists('components/$project/site-config');
 
 prefix '/software/components/$project';
 'active' ?= true;


### PR DESCRIPTION
Otherwise the files would need to be named "site-config.pan.pan".
  