### PR TITLE
Test-Quattor-Component prefix uses name when using component submodules

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor/Component.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Component.pm
@@ -53,7 +53,7 @@ sub prefix
     my $self = shift;
 
     my @ns = split(/::/, ref($self));
-    return "/software/components/$ns[-1]";
+    return "/software/components/" . (scalar @ns == 3 ? $ns[-1] : $self->{name});
 }
 
 # A private method only here to disable the deprecation warnings

--- a/build-scripts/src/main/perl/Test/Quattor/namespace/ncm/NCM/Component/Test/Example.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/namespace/ncm/NCM/Component/Test/Example.pm
@@ -1,0 +1,11 @@
+package NCM::Component::Test::Example;
+
+use strict;
+use warnings;
+
+# Correct the namespace for Test::Quattor::Component
+use parent qw(NCM::Component Exporter);
+
+# reexport NoAction
+our @EXPORT = qw($NoAction);
+1;

--- a/build-scripts/src/test/perl/component.t
+++ b/build-scripts/src/test/perl/component.t
@@ -13,6 +13,7 @@ BEGIN {
 use Test::More;
 use Test::Quattor::Component;
 use NCM::Component;
+use NCM::Component::Test::Example;
 
 use EDG::WP4::CCM::Path qw(escape unescape);
 
@@ -38,5 +39,7 @@ sub test
 test($test_comp, "Test::Quattor::Component");
 test($ncm_comp, "NCM::Component");
 
+my $test = NCM::Component::Test::Example->new('test');
+is($test->prefix(), '/software/components/test');
 
 done_testing();


### PR DESCRIPTION
eg When using submodules like NCM::Component::Ceph::Luminous we should be able to set the component name to 'ceph' in the tests.
