### PR TITLE
Allow builds to succeed even if javadoc doclint fails

### DIFF
--- a/assemblies/pom.xml
+++ b/assemblies/pom.xml
@@ -1,45 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <artifactId>assemblies</artifactId>
   <packaging>pom</packaging>
-
   <name>assemblies</name>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>maven</artifactId>
     <version>1.58-SNAPSHOT</version>
   </parent>
-
   <build>
     <plugins>
-
       <plugin>
         <artifactId>maven-assembly-plugin</artifactId>
         <extensions>true</extensions>
-
         <executions>
-
-	  <execution>
-	    <id>assemblies</id>
-	    <phase>package</phase>
-	    <goals>
-	      <goal>attached</goal>
-	    </goals>
-	    <configuration>
-	      <descriptors>
-		<descriptor>src/main/assembly/assemblies.xml</descriptor>
-	      </descriptors>
-	    </configuration>
-	  </execution>
-
+          <execution>
+            <id>assemblies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>attached</goal>
+            </goals>
+            <configuration>
+              <descriptors>
+                <descriptor>src/main/assembly/assemblies.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
         </executions>
-
       </plugin>
-
     </plugins>
   </build>
-
 </project>

--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>build-profile</artifactId>
@@ -19,7 +20,7 @@
     </build-info>
     <man.page.dir>/usr/share/man</man.page.dir>
     <prove.args>-q</prove.args>
-    <unittest />
+    <unittest/>
     <!-- perl module headers.
          Usage: at the beginning of the module put:
          #${PMpre} Some::Namespace::packagename${PMpost}
@@ -48,7 +49,6 @@ use version;
 our $VERSION = version-&gt;new("v${no-snapshot-version}");
 ${line.separator}
     </PMpost>
-
     <!--
         Generic component config.pan template
             Assumes main component type to be named <name>_component
@@ -75,12 +75,10 @@ prefix '/software/components/${project.artifactId}';
 'dispatch' ?= true;
 'version' ?= '${no-snapshot-version}';
     </componentconfignospma>
-
     <componentconfig>
 ${componentconfignospma}
 'dependencies/pre' ?= list('spma');
     </componentconfig>
-
     <componentschema>
 ${license-info}
 ${developer-info}
@@ -88,7 +86,6 @@ ${author-info}
 
 declaration template components/${project.artifactId}/schema;
     </componentschema>
-
     <changelogtimestamp>${maven.build.timestamp}</changelogtimestamp>
     <maven.build.timestamp.format>E MMM dd yyyy</maven.build.timestamp.format>
   </properties>

--- a/build-scripts/pom.xml
+++ b/build-scripts/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <artifactId>build-scripts</artifactId>
@@ -11,7 +12,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <prove.args>-q</prove.args>
-    <unittest />
+    <unittest/>
   </properties>
   <build>
     <plugins>

--- a/cfg-module/pom.xml
+++ b/cfg-module/pom.xml
@@ -1,54 +1,42 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <artifactId>cfg-module</artifactId>
-
   <name>quattor cfg. module archetype</name>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>maven</artifactId>
     <version>1.58-SNAPSHOT</version>
   </parent>
-
   <build>
     <plugins>
       <plugin>
-	
-	<groupId>org.apache.maven.plugins</groupId>
-	<artifactId>maven-resources-plugin</artifactId>
-	
-	<executions>
-	  
-	  <execution>
-	    <id>filter-archetype-resources</id>
-	    <goals>
-	      <goal>copy-resources</goal>
-	    </goals>
-	    <phase>process-resources</phase>
-	    <configuration>
-	      <encoding>UTF-8</encoding>
-	      <useDefaultDelimiters>false</useDefaultDelimiters>
-	      <outputDirectory>${project.build.outputDirectory}</outputDirectory>
-	      <delimiters>
-		<delimiter>%%{*}%%</delimiter>
-	      </delimiters>
-	      <resources>
-		<resource>
-		  <directory>src/main/resources</directory>
-		  <filtering>true</filtering>
-		</resource>
-	      </resources>
-	    </configuration> 
-	  </execution>
-	  
-	</executions>
-	
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>filter-archetype-resources</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <encoding>UTF-8</encoding>
+              <useDefaultDelimiters>false</useDefaultDelimiters>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <delimiters>
+                <delimiter>%%{*}%%</delimiter>
+              </delimiters>
+              <resources>
+                <resource>
+                  <directory>src/main/resources</directory>
+                  <filtering>true</filtering>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
-      
     </plugins>
   </build>
-
 </project>

--- a/cfg-module/src/main/resources/archetype-resources/pom.xml
+++ b/cfg-module/src/main/resources/archetype-resources/pom.xml
@@ -1,23 +1,16 @@
-<project
-    xmlns="http://maven.apache.org/POM/4.0.0"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+<?xml version="1.0" encoding="utf-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
-
   <groupId>${groupId}</groupId>
   <artifactId>${artifactId}</artifactId>
-
   <packaging>pom</packaging>
   <version>${version}</version>
   <name>${description}</name>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>%%{version}%%</version>
   </parent>
-
   <licenses>
     <license>
       <name>Apache 2 License</name>
@@ -25,29 +18,26 @@
       <comments>Copyright (c) Responsible Organization</comments>
     </license>
   </licenses>
-
   <developers>
     <developer>
       <name>${developer}</name>
       <email>${developer-email}</email>
     </developer>
   </developers>
-
   <contributors>
     <contributor>
       <name>Jane SMITH</name>
       <email>smith@example.com</email>
       <roles>
-	<role>author</role>
+        <role>author</role>
       </roles>
     </contributor>
     <contributor>
       <name>Joe DOE</name>
       <email>doe@example.org</email>
       <roles>
-	<role>author</role>
+        <role>author</role>
       </roles>
     </contributor>
   </contributors>
-
 </project>

--- a/package-build-scripts/pom.xml
+++ b/package-build-scripts/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.quattor.client.libraries</groupId>
@@ -9,7 +10,7 @@
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
     <version>1.49</version>
-    <relativePath />
+    <relativePath/>
   </parent>
   <licenses>
     <license>
@@ -35,7 +36,7 @@
     </contributor>
   </contributors>
   <properties>
-    <unittest />
+    <unittest/>
   </properties>
   <build>
     <plugins>
@@ -118,9 +119,9 @@
             <configuration>
               <tasks name="Rename">
                 <move filtering="true" todir="${project.build.directory}/doc/pod/Test">
-                  <fileset dir="${project.build.directory}/doc/pod/Test" />
+                  <fileset dir="${project.build.directory}/doc/pod/Test"/>
                   <mapper>
-                    <globmapper from="*.pm" to="*.pod" />
+                    <globmapper from="*.pm" to="*.pod"/>
                   </mapper>
                 </move>
                 <echo>Renaming stuff?</echo>

--- a/pom.xml
+++ b/pom.xml
@@ -110,6 +110,13 @@
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <configuration>
+            <additionalparam>-Xdoclint:none</additionalparam>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>2.5.5</version>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,17 +1,13 @@
-<?xml version="1.0" encoding="UTF-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <groupId>org.quattor.maven</groupId>
   <artifactId>maven</artifactId>
   <version>1.58-SNAPSHOT</version>
   <packaging>pom</packaging>
-
   <name>quattor maven build tools</name>
   <description>quattor maven build tools</description>
   <url>http://quattor.org</url>
-
   <licenses>
     <license>
       <name>The Apache Software License, Version 2.0</name>
@@ -19,17 +15,14 @@
       <distribution>repo</distribution>
     </license>
   </licenses>
-
   <parent>
     <groupId>org.sonatype.oss</groupId>
     <artifactId>oss-parent</artifactId>
     <version>7</version>
   </parent>
-
   <prerequisites>
     <maven>3.0.0</maven>
   </prerequisites>
-
   <modules>
     <module>assemblies</module>
     <module>build-profile</module>
@@ -37,23 +30,19 @@
     <module>cfg-module</module>
     <module>quattor-build-maven-plugin</module>
   </modules>
-
   <organization>
     <name>Quattor</name>
     <url>http://quattor.org/</url>
   </organization>
-
   <scm>
     <connection>scm:git:git://github.com/quattor/maven-tools.git</connection>
     <developerConnection>scm:git:git@github.com:quattor/maven-tools.git</developerConnection>
     <url>https://github.com/quattor/maven-tools</url>
   </scm>
-
   <issueManagement>
     <system>GitHub tracker</system>
     <url>https://github.com/quattor/maven-tools</url>
   </issueManagement>
-
   <mailingLists>
     <mailingList>
       <name>Quattor Discuss</name>
@@ -62,7 +51,6 @@
       <archive>https://sourceforge.net/mailarchive/forum.php?forum_name=quattor-discuss</archive>
     </mailingList>
   </mailingLists>
-
   <developers>
     <developer>
       <id>loomisc</id>
@@ -70,28 +58,22 @@
       <email>loomis@lal.in2p3.fr</email>
     </developer>
   </developers>
-
   <profiles>
     <profile>
       <id>release-signed-artifacts</id>
       <activation>
-
-	<!--
+        <!--
         <file>
           <exists>/tmp</exists>
         </file>
 	-->
-
-	<property>
-	  <name>performRelease</name>
-	  <value>true</value>
-	</property>
-
+        <property>
+          <name>performRelease</name>
+          <value>true</value>
+        </property>
       </activation>
       <build>
-
         <plugins>
-
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
@@ -106,123 +88,101 @@
               </execution>
             </executions>
           </plugin>
-
-	  <plugin>
-	    <groupId>org.apache.maven.plugins</groupId>
-	    <artifactId>maven-release-plugin</artifactId>
-	    <configuration>
-	      <arguments>-Dmyprop=value -Psonatype-oss-release</arguments>
-	    </configuration>
-	  </plugin>
-
-	</plugins>
-
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-release-plugin</artifactId>
+            <configuration>
+              <arguments>-Dmyprop=value -Psonatype-oss-release</arguments>
+            </configuration>
+          </plugin>
+        </plugins>
       </build>
     </profile>
   </profiles>
-
   <build>
     <pluginManagement>
       <plugins>
-
-	<plugin>
-	  <artifactId>maven-release-plugin</artifactId>
-	  <configuration>
-	    <arguments>${arguments} -Psonatype-oss-release</arguments>
-	  </configuration>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-assembly-plugin</artifactId>
-	  <version>2.5.5</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-plugin-plugin</artifactId>
-	  <version>2.6</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-jar-plugin</artifactId>
-	  <version>2.5</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-surefire-plugin</artifactId>
-	  <version>2.18.1</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-compiler-plugin</artifactId>
-	  <version>3.2</version>
-	  <configuration>
-	    <target>1.5</target>
-	    <source>1.5</source>
-	  </configuration>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-clean-plugin</artifactId>
-	  <version>2.6.1</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-deploy-plugin</artifactId>
-	  <version>2.8.2</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-install-plugin</artifactId>
-	  <version>2.5.2</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-site-plugin</artifactId>
-	  <version>3.4</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-dependency-plugin</artifactId>
-	  <version>2.10</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-resources-plugin</artifactId>
-	  <version>2.4.3</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.codehaus.mojo</groupId>
-	  <artifactId>exec-maven-plugin</artifactId>
-	  <version>1.4.0</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.codehaus.mojo</groupId>
-	  <artifactId>rpm-maven-plugin</artifactId>
-	  <version>2.1.5</version>
-	</plugin>
-
-	<plugin>
-	  <groupId>org.apache.maven.plugins</groupId>
-	  <artifactId>maven-antrun-plugin</artifactId>
-	  <version>1.8</version>
-	</plugin>
-
+        <plugin>
+          <artifactId>maven-release-plugin</artifactId>
+          <configuration>
+            <arguments>${arguments} -Psonatype-oss-release</arguments>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>2.5.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-plugin-plugin</artifactId>
+          <version>2.6</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <version>2.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.18.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>3.2</version>
+          <configuration>
+            <target>1.5</target>
+            <source>1.5</source>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-clean-plugin</artifactId>
+          <version>2.6.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-deploy-plugin</artifactId>
+          <version>2.8.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-install-plugin</artifactId>
+          <version>2.5.2</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-site-plugin</artifactId>
+          <version>3.4</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-dependency-plugin</artifactId>
+          <version>2.10</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>2.4.3</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>exec-maven-plugin</artifactId>
+          <version>1.4.0</version>
+        </plugin>
+        <plugin>
+          <groupId>org.codehaus.mojo</groupId>
+          <artifactId>rpm-maven-plugin</artifactId>
+          <version>2.1.5</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>1.8</version>
+        </plugin>
       </plugins>
-
     </pluginManagement>
   </build>
-
 </project>

--- a/quattor-build-maven-plugin/pom.xml
+++ b/quattor-build-maven-plugin/pom.xml
@@ -1,37 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
   <modelVersion>4.0.0</modelVersion>
-
   <artifactId>quattor-build-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
-
   <name>quattor build maven plugin</name>
-
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>maven</artifactId>
     <version>1.58-SNAPSHOT</version>
   </parent>
-
   <dependencies>
-
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
       <version>2.2.1</version>
     </dependency>
-
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-model</artifactId>
       <version>2.2.1</version>
     </dependency>
-
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
       <version>2.2.1</version>
     </dependency>
-
   </dependencies>
 </project>


### PR DESCRIPTION
* Reformat pom files with xmllint in utf-8 mode for consistency.
* Disable doclint to allow builds with JDK 1.8+.
  In JDK 1.8+ doclint errors cause the build to fail, this restores the more tolerant behaviour.

This change requires JDK 1.8+.