### PR TITLE
Update defaults for critic and tidy tests to off

### DIFF
--- a/build-scripts/src/main/perl/Test/Quattor/Unittest.pm
+++ b/build-scripts/src/main/perl/Test/Quattor/Unittest.pm
@@ -70,10 +70,10 @@ enable = 1
 enable = 1
 
 [critic]
-enable = 1
+enable = 0
 
 [tidy]
-enable = 1
+enable = 0
 
 EOF
 


### PR DESCRIPTION
Disable the defaut running of the critic and tidy tests. The code base
currently does not comply with either of these standards which leads to
a very large amount of output being sent to the console.

These tests are definitely the right direction but I think enabling them selectively, only for files that have changed, will help us slowly uplift the code.