### PR TITLE
package-build-scripts: Update build tools to 1.62

### DIFF
--- a/package-build-scripts/pom.xml
+++ b/package-build-scripts/pom.xml
@@ -9,7 +9,7 @@
   <parent>
     <groupId>org.quattor.maven</groupId>
     <artifactId>build-profile</artifactId>
-    <version>1.61</version>
+    <version>1.62</version>
     <relativePath />
   </parent>
   <licenses>


### PR DESCRIPTION
This is more important than usual as 1.61 is missing from Nexus.