### PR TITLE
Build source RPMs by default

### DIFF
--- a/build-profile/pom.xml
+++ b/build-profile/pom.xml
@@ -500,6 +500,7 @@ declaration template components/${project.artifactId}/schema;
             <changelogFile>${project.build.directory}/ChangeLog.template</changelogFile>
             <needarch>noarch</needarch>
             <description>${project.name}</description>
+            <rpmbuildStage>-ba</rpmbuildStage><!-- Build binary and source packages -->
             <mappings>
               <mapping>
                 <directory>/usr/lib</directory>


### PR DESCRIPTION
This was waiting on rpm-maven-plugin v2.2.0 which we updated to in 64e54ad.

Resolves quattor/release#117.